### PR TITLE
Bump module version, reconfigure ECS service and remove LB configuration

### DIFF
--- a/terraform/groups/ecs-service/data.tf
+++ b/terraform/groups/ecs-service/data.tf
@@ -30,11 +30,6 @@ data "aws_lb" "service_lb" {
   name = "${var.environment}-chs-accountchgovuk"
 }
 
-data "aws_lb_listener" "service_lb_listener" {
-  load_balancer_arn = data.aws_lb.service_lb.arn
-  port = 443
-}
-
 data "aws_ecs_cluster" "ecs_cluster" {
   cluster_name = "${local.name_prefix}-cluster"
 }
@@ -62,7 +57,6 @@ data "aws_ssm_parameter" "global_secret" {
   name     = each.key
 }
 
-// --- s3 bucket for shared services config ---
 data "vault_generic_secret" "shared_s3" {
   path = "aws-accounts/shared-services/s3"
 }

--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -7,9 +7,7 @@ locals {
   container_port              = "8080"
   docker_repo                 = "filing-history-delta-consumer"
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
-  lb_listener_rule_priority   = 10
-  lb_listener_paths           = ["/filing-history-delta-consumer/*"]
-  healthcheck_path            = "/filing-history-delta-consumer/healthcheck" #healthcheck path for filing-history-delta-consumer
+  healthcheck_path            = "/healthcheck" #healthcheck path for filing-history-delta-consumer
   healthcheck_matcher         = "200"
   vpc_name                    = local.stack_secrets["vpc_name"]
   s3_config_bucket            = data.vault_generic_secret.shared_s3.data["config_bucket_name"]

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.235"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.236"
 
 
   # Environmental configuration
@@ -29,11 +29,7 @@ module "ecs-service" {
   vpc_id                  = data.aws_vpc.vpc.id
   ecs_cluster_id          = data.aws_ecs_cluster.ecs_cluster.id
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
-
-  # Load balancer configuration
-  lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
-  lb_listener_rule_priority       = local.lb_listener_rule_priority
-  lb_listener_paths               = local.lb_listener_paths
+  batch_service           = true
 
   # ECS Task container health check
   use_task_container_healthcheck = true
@@ -63,14 +59,11 @@ module "ecs-service" {
   use_fargate                        = var.use_fargate
   fargate_subnets                    = local.application_subnet_ids
 
-  # Cloudwatch
-  cloudwatch_alarms_enabled = var.cloudwatch_alarms_enabled
-
   # Service environment variable and secret configs
-  task_environment            = local.task_environment
-  task_secrets                = local.task_secrets
-  app_environment_filename    = local.app_environment_filename
-  use_set_environment_files   = local.use_set_environment_files
+  task_environment          = local.task_environment
+  task_secrets              = local.task_secrets
+  app_environment_filename  = local.app_environment_filename
+  use_set_environment_files = local.use_set_environment_files
 }
 
 module "secrets" {


### PR DESCRIPTION
Updates the `ecs-module` version to 1.0.236
Reconfigures the ECS service to run in "batch" mode which doesn't require an LB listener, target group or LB-based healthchecks
Removed CloudWatch alarm creation as this applies only to the LB and target group resources
Removed extraneous data lookup
Removed extraneous locals