### PR TITLE
DSND-2462: POC to demonstrate file encryption

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.2.2</spring.boot.version>
+    <spring.boot.version>3.2.3</spring.boot.version>
     <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
     <test-containers.version>1.19.3</test-containers.version>
     <maven-surefire.version>3.2.3</maven-surefire.version>
@@ -32,7 +32,7 @@
     <structured-logging.version>3.0.1</structured-logging.version>
     <sdk-manager-java.version>3.0.3</sdk-manager-java.version>
     <private-api-sdk-java.version>4.0.70</private-api-sdk-java.version>
-    <kafka-models.version>3.0.4</kafka-models.version>
+    <kafka-models.version>3.0.7</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->
     <logback.version>1.4.14</logback.version>
@@ -97,6 +97,18 @@
       <artifactId>jackson-dataformat-yaml</artifactId>
       <version>${jackson-databind.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-compress</artifactId>
+      <version>1.26.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.bitbucket.b_c</groupId>
+      <artifactId>jose4j</artifactId>
+      <version>0.9.6</version>
+      <scope>test</scope>
+    </dependency>
+
     <!--end transitive dependencies-->
 
     <dependency>

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtils.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtils.java
@@ -1,0 +1,120 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.nio.file.Files;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
+import javax.crypto.BadPaddingException;
+import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.SecretKeyFactory;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.PBEKeySpec;
+import javax.crypto.spec.SecretKeySpec;
+
+public class FileEncryptionUtils {
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final String FACTORY_INSTANCE = "PBKDF2WithHmacSHA256";
+    private static final int TAG_LENGTH_BIT = 128;
+    private static final int IV_LENGTH_BYTE = 12;
+    private static final int SALT_LENGTH_BYTE = 16;
+    private static final String ALGORITHM_TYPE = "AES";
+    private static final int KEY_LENGTH = 256;
+    private static final int ITERATION_COUNT = 65536;
+    private static final String ENCRYPTED_EXT = ".enc";
+
+    public static void encryptFile(String password, File inputFile) {
+        try {
+            byte[] salt = getRandomNonce(SALT_LENGTH_BYTE);
+            SecretKey secretKey = getSecretKey(password, salt);
+
+            byte[] iv = getRandomNonce(IV_LENGTH_BYTE);
+            Cipher cipher = initCipher(Cipher.ENCRYPT_MODE, secretKey, iv);
+
+            byte[] content = Files.readAllBytes(inputFile.toPath());
+            byte[] encryptedBytes = cipher.doFinal(content);
+            byte[] cipherBytes = ByteBuffer.allocate(iv.length + salt.length + encryptedBytes.length)
+                    .put(iv)
+                    .put(salt)
+                    .put(encryptedBytes)
+                    .array();
+
+            File encryptedFile = new File(inputFile.getPath() + ENCRYPTED_EXT);
+            try (FileOutputStream outputStream = new FileOutputStream(encryptedFile)) {
+                outputStream.write(cipherBytes);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new IllegalArgumentException("Invalid cipher configuration", e);
+        }
+    }
+
+    public static String decryptFile(String password, File encryptedFile) {
+        try {
+            byte[] encryptedBytes = Files.readAllBytes(encryptedFile.toPath());
+            ByteBuffer byteBuffer = ByteBuffer.wrap(encryptedBytes);
+
+            byte[] iv = new byte[IV_LENGTH_BYTE];
+            byteBuffer.get(iv);
+
+            byte[] salt = new byte[SALT_LENGTH_BYTE];
+            byteBuffer.get(salt);
+
+            byte[] contentBytes = new byte[byteBuffer.remaining()];
+            byteBuffer.get(contentBytes);
+
+            SecretKey secretKey = getSecretKey(password, salt);
+            Cipher cipher = initCipher(Cipher.DECRYPT_MODE, secretKey, iv);
+
+            byte[] decryptedMessageByte = cipher.doFinal(contentBytes);
+            return new String(decryptedMessageByte, UTF_8);
+        } catch (IllegalBlockSizeException | BadPaddingException e) {
+            throw new IllegalArgumentException("Invalid cipher configuration", e);
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static byte[] getRandomNonce(int length) {
+        byte[] nonce = new byte[length];
+        new SecureRandom().nextBytes(nonce);
+        return nonce;
+    }
+
+    private static SecretKey getSecretKey(String password, byte[] salt) {
+        try {
+            KeySpec spec = new PBEKeySpec(password.toCharArray(), salt, ITERATION_COUNT, KEY_LENGTH);
+            SecretKeyFactory factory = SecretKeyFactory.getInstance(FACTORY_INSTANCE);
+
+            return new SecretKeySpec(factory.generateSecret(spec).getEncoded(), ALGORITHM_TYPE);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new IllegalArgumentException("Invalid encryption algorithm configuration", e);
+        }
+    }
+
+    private static Cipher initCipher(int mode, SecretKey secretKey, byte[] iv) {
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(mode, secretKey, new GCMParameterSpec(TAG_LENGTH_BIT, iv));
+
+            return cipher;
+        } catch (NoSuchAlgorithmException | NoSuchPaddingException | InvalidAlgorithmParameterException |
+                 InvalidKeyException e) {
+            throw new IllegalArgumentException("Invalid cipher configuration", e);
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtilsTest.java
@@ -1,0 +1,38 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class FileEncryptionUtilsTest {
+
+    private static final String DELTA_JSON_SUFFIX = "_delta.json";
+    private static final String PASSWORD = "MySecretKeyFromTheKeyStore";
+    private static final String ENCRYPTED_EXT = ".enc";
+
+    @ParameterizedTest
+    @CsvSource({"officers/TM01", "capital/SH07"})
+    void shouldEncryptAndDecryptTestDelta(String sourceRootName) throws IOException {
+
+        File inputFile = Paths.get("src/test/resources/data/%s%s".formatted(sourceRootName, DELTA_JSON_SUFFIX))
+                .toFile();
+        String deltaContent = Files.readString(inputFile.toPath(), StandardCharsets.UTF_8);
+        File encryptedFile = new File(inputFile.getPath() + ENCRYPTED_EXT);
+
+        // when
+        FileEncryptionUtils.encryptFile(PASSWORD, inputFile);
+        String decryptedContent = FileEncryptionUtils.decryptFile(PASSWORD, encryptedFile);
+
+        // then
+        assertEquals(deltaContent, decryptedContent);
+
+        // encryptedFile.deleteOnExit();
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtilsTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/FileEncryptionUtilsTest.java
@@ -32,7 +32,7 @@ class FileEncryptionUtilsTest {
         // then
         assertEquals(deltaContent, decryptedContent);
 
-        // encryptedFile.deleteOnExit();
+        encryptedFile.deleteOnExit();
     }
 }
 


### PR DESCRIPTION
## Describe the changes
The use of test data derived from the live database means that all these file must be encrypted with a 
string algorithm.

* Encrypts JSON documents derived from live data
* Decrypted encrypted files to a JSON string
* Uses the encryption algorithm, AES/GCM/NoPadding, as suggested by the Application Security team

### Related Jira tickets
[DSND-2462](https://companieshouse.atlassian.net/browse/DSND-2462)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2462]: https://companieshouse.atlassian.net/browse/DSND-2462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ