### PR TITLE
DSND-2405: Fixes bug where original_values dates were transformed twice

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ immediately to the <br>`filing-history-delta-filing-history-delta-consumer-inval
 
 ## Building the docker image
 
-    mvn compile jib:dockerBuild
+    mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
 
 ## To make local changes
 

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/ResponseHandler.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/ResponseHandler.java
@@ -16,8 +16,8 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class ResponseHandler {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
-    private static final String API_ERROR_RESPONSE_MESSAGE = "HTTP response code %d when upserting filing history";
-    private static final String URI_VALIDATION_EXCEPTION_MESSAGE = "Failed to upsert filing history due to invalid URI";
+    private static final String API_ERROR_RESPONSE_MESSAGE = "HTTP response code %d when calling filing history API";
+    private static final String URI_VALIDATION_EXCEPTION_MESSAGE = "Failed call to filing history API due to invalid URI";
 
     public void handle(ApiErrorResponseException ex) {
         final int statusCode = ex.getStatusCode();

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/OriginalValuesMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/OriginalValuesMapper.java
@@ -5,16 +5,9 @@ import static uk.gov.companieshouse.filinghistory.consumer.mapper.MapperUtils.ge
 import com.fasterxml.jackson.databind.JsonNode;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.InternalDataOriginalValues;
-import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.FormatDate;
 
 @Component
 public class OriginalValuesMapper {
-
-    private final FormatDate formatDate;
-
-    public OriginalValuesMapper(FormatDate formatDate) {
-        this.formatDate = formatDate;
-    }
 
     public InternalDataOriginalValues map(JsonNode jsonNode) {
         if (jsonNode == null) {
@@ -30,7 +23,7 @@ public class OriginalValuesMapper {
                 .caseEndDate(getFieldValueFromJsonNode(jsonNode, "case_end_date"))
                 .cessationDate(getFieldValueFromJsonNode(jsonNode, "cessation_date"))
                 .changeDate(getFieldValueFromJsonNode(jsonNode, "change_date"))
-                .chargeCreationDate(formatDate.format(getFieldValueFromJsonNode(jsonNode, "charge_creation_date")))
+                .chargeCreationDate(getFieldValueFromJsonNode(jsonNode, "charge_creation_date"))
                 .madeUpDate(getFieldValueFromJsonNode(jsonNode, "made_up_date"))
                 .mortgageSatisfactionDate(getFieldValueFromJsonNode(jsonNode, "mortgage_satisfaction_date"))
                 .newRoAddress(getFieldValueFromJsonNode(jsonNode, "new_ro_address"))
@@ -38,7 +31,7 @@ public class OriginalValuesMapper {
                 .notificationDate(getFieldValueFromJsonNode(jsonNode, "notification_date"))
                 .officerName(getFieldValueFromJsonNode(jsonNode, "officer_name"))
                 .periodType(getFieldValueFromJsonNode(jsonNode, "period_type"))
-                .propertyAcquiredDate(formatDate.format(getFieldValueFromJsonNode(jsonNode, "property_acquired_date")))
+                .propertyAcquiredDate(getFieldValueFromJsonNode(jsonNode, "property_acquired_date"))
                 .pscName(getFieldValueFromJsonNode(jsonNode, "psc_name"))
                 .resignationDate(getFieldValueFromJsonNode(jsonNode, "resignation_date"));
     }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -95,7 +95,7 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
             "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
 
 
-            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_4", "mortgage/MR03_rule_4",
+            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_3", "mortgage/MR02_rule_4", "mortgage/MR03_rule_4",
             "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
             "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
             "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/OriginalValuesMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/OriginalValuesMapperTest.java
@@ -2,21 +2,15 @@ package uk.gov.companieshouse.filinghistory.consumer.mapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.filinghistory.InternalDataOriginalValues;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.TransformerTestingUtils;
-import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.FormatDate;
 
 @ExtendWith(MockitoExtension.class)
 class OriginalValuesMapperTest {
@@ -25,8 +19,6 @@ class OriginalValuesMapperTest {
 
     @InjectMocks
     private OriginalValuesMapper originalValuesMapper;
-    @Mock
-    private FormatDate formatDate;
 
     @Test
     void shouldMapOriginalValuesFromJsonNode() {
@@ -64,7 +56,7 @@ class OriginalValuesMapperTest {
                 .caseEndDate("06/05/2013")
                 .cessationDate("05/06/2013")
                 .changeDate("04/04/2013")
-                .chargeCreationDate("2014-05-05T00:00:00Z")
+                .chargeCreationDate("05/05/2014")
                 .madeUpDate("09/09/2018")
                 .mortgageSatisfactionDate("20/10/2005")
                 .newRoAddress("5 Test Road")
@@ -72,19 +64,15 @@ class OriginalValuesMapperTest {
                 .notificationDate("11/11/2020")
                 .officerName("John Doe")
                 .periodType("weeks")
-                .propertyAcquiredDate("2021-12-12T00:00:00Z")
+                .propertyAcquiredDate("12/12/2021")
                 .pscName("Significant Person")
                 .resignationDate("03/02/2013");
-
-        when(formatDate.format("05/05/2014")).thenReturn("2014-05-05T00:00:00Z");
-        when(formatDate.format("12/12/2021")).thenReturn("2021-12-12T00:00:00Z");
 
         // when
         final InternalDataOriginalValues actual = originalValuesMapper.map(jsonNode);
 
         // then
         assertEquals(expected, actual);
-        verify(formatDate, times(2)).format(any());
     }
 
     @Test

--- a/src/test/resources/data/mortgage/MR02_rule_3_delta.json
+++ b/src/test/resources/data/mortgage/MR02_rule_3_delta.json
@@ -1,0 +1,21 @@
+{
+  "filing_history": [
+    {
+      "category": "4",
+      "receive_date": "20140906000000",
+      "form_type": "MR02",
+      "description": "ACQUISITION OF A CHARGE / CHARGE CODE  123456780657",
+      "barcode": "A3FTQQVF",
+      "document_id": "000A3FTQQVF5668",
+      "company_number": "12345678",
+      "entity_id": "3107678025",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "description_values": {
+        "property_acquired_date": "21/08/2014"
+      },
+      "pre_scanned_batch": "1"
+    }
+  ],
+  "delta_at": "20211029142043360560"
+}

--- a/src/test/resources/data/mortgage/MR02_rule_3_request_body.json
+++ b/src/test/resources/data/mortgage/MR02_rule_3_request_body.json
@@ -1,0 +1,33 @@
+{
+  "external_data": {
+    "transaction_id": "MzEwNzY3ODAyNXNhbHQ",
+    "barcode": "A3FTQQVF",
+    "action_date": "2014-08-21T00:00:00Z",
+    "category": "mortgage",
+    "date": "2014-09-06T00:00:00Z",
+    "description": "mortgage-acquire-with-deed-with-charge-number-charge-acquisition-date",
+    "description_values": {
+      "charge_number": "123456780657",
+      "property_acquired_date": "2014-08-21T00:00:00Z"
+    },
+    "links": {
+      "self": "/company/12345678/filing-history/MzEwNzY3ODAyNXNhbHQ"
+    },
+    "paper_filed": true,
+    "subcategory": "acquire",
+    "type": "MR02"
+  },
+  "internal_data": {
+    "original_description": "Acquisition of a charge / charge code 123456780657",
+    "original_values": {
+      "property_acquired_date": "2014-08-21T00:00:00Z"
+    },
+    "company_number": "12345678",
+    "document_id": "000A3FTQQVF5668",
+    "entity_id": "3107678025",
+    "parent_entity_id": "",
+    "delta_at": "20211029142043360560",
+    "updated_by": "context_id",
+    "transaction_kind": "top-level"
+  }
+}


### PR DESCRIPTION
## Describe the changes
* Original values fields were being transformed once by YAML and once post YAML, have removed the second time post YAML.
* MR02 integration test confirms fix is working as intended.
* Updated README with proper docker build command.

### Related Jira tickets
[DSND-2405](https://companieshouse.atlassian.net/browse/DSND-2405)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2405]: https://companieshouse.atlassian.net/browse/DSND-2405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ