### PR TITLE
DSND-2503: Stop FormatDate.format() being called twice and failing on the 2nd pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,21 @@ services and modules will be started as dependencies of these two):
 To run the tests from the command line use:
 
 ```shell
-HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> PERL_SALT=<perl_salt> \
+HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> PERL_SALT=<perl_salt> RUN_BULK_TEST=1 \
 mvn test -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
 ```
 
-_Note:_ `kermit_password` can be found in [Confluence](
+_Note:_
+
+* `kermit_password` can be found in [Confluence](
 https://companieshouse.atlassian.net/wiki/spaces/TH/pages/4029120676/Harmonia+Testing+Process) and
 `perl_salt` can be found in
 the [chs-backend](https://github.com/companieshouse/chs-backend/blob/93494b863fcbb97e99195e54770b30b8ebcd4668/lib/ChsBackend/Roles/Transform.pm#L416)
 repository
+* To run the tests in IntelliJ
+  add `HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> PERL_SALT=<perl_salt> RUN_BULK_TEST=1` settings
+  to the Environment Variables section of the run
+  configuration dialog.
 
 ### IMPORTANT
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,14 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.2.3</spring.boot.version>
+    <spring.boot.version>3.2.4</spring.boot.version>
     <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
     <test-containers.version>1.19.3</test-containers.version>
     <maven-surefire.version>3.2.3</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
     <commons-text.version>1.11.0</commons-text.version>
-    <wiremock.version>3.3.1</wiremock.version>
+    <wiremock.version>3.5.2</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDate.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDate.java
@@ -13,8 +13,10 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.filinghistory.consumer.exception.NonRetryableException;
 import uk.gov.companieshouse.filinghistory.consumer.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -30,6 +32,7 @@ public class FormatDate extends AbstractTransformer {
             .appendPattern("d/MM/")
             .appendValueReduced(ChronoField.YEAR, 2, 2, 1970)
             .toFormatter();
+    private static final Pattern ISO_DATE_PATTERN = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$");
 
     public FormatDate(ObjectMapper objectMapper) {
         super(objectMapper);
@@ -38,12 +41,22 @@ public class FormatDate extends AbstractTransformer {
     @Override
     protected void doTransform(JsonNode source, TransformTarget target, List<String> arguments,
             Map<String, String> context) {
-        target.objectNode().put(target.fieldKey(), format(target.fieldValue()));
+        target.objectNode().put(target.fieldKey(), formatIfRequired(target.fieldValue()));
     }
 
     public String format(String nodeText) {
+        return doFormat(nodeText);
+    }
 
-        // TODO Check if nodeText is already in the correct format
+    public String formatIfRequired(String nodeText) {
+        if (ISO_DATE_PATTERN.matcher(nodeText).matches()) {
+            return nodeText;
+        }
+        return doFormat(nodeText);
+    }
+
+    private String doFormat(String nodeText) {
+
         try {
             if (StringUtils.isEmpty(nodeText)) {
                 return nodeText;
@@ -62,8 +75,7 @@ public class FormatDate extends AbstractTransformer {
             return DateTimeFormatter.ISO_INSTANT.format(nodeTextAsDate.toInstant());
         } catch (Exception e) {
             logger.error(e.getMessage(), e, DataMapHolder.getLogMap());
-            throw new RuntimeException(e);
+            throw new NonRetryableException("Failed to parse date string %s".formatted(nodeText), e);
         }
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDate.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDate.java
@@ -48,8 +48,8 @@ public class FormatDate extends AbstractTransformer {
         return doFormat(nodeText);
     }
 
-    public String formatIfRequired(String nodeText) {
-        if (ISO_DATE_PATTERN.matcher(nodeText).matches()) {
+    private String formatIfRequired(String nodeText) {
+        if (nodeText == null || ISO_DATE_PATTERN.matcher(nodeText).matches()) {
             return nodeText;
         }
         return doFormat(nodeText);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -29,6 +29,7 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
 import org.junit.jupiter.params.provider.CsvSource;
@@ -66,28 +67,15 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
 
     @ParameterizedTest
     @CsvSource({
-            "officers/EW01RSS",
-            "officers/TM01",
+            "officers/EW01RSS", "officers/TM01",
 
-            "capital/SH03",
-            "capital/SH07",
-              "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4", "capital/SH05",
+            "capital/SH03", "capital/SH07", "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4",
+            "capital/SH05", "capital/EW05RSS",
 
-            "accounts/AA_rule_17",
-            "accounts/AA_rule_9",
-            "accounts/AA_rule_10",
-            "accounts/AA_rule_8",
-            "accounts/AA_rule_6",
-            "accounts/AA_rule_12",
-            "accounts/AA_rule_14",
-            "accounts/AA_rule_20",
-            "accounts/AA_rule_23",
-            "accounts/AA_rule_25",
-            "accounts/AA_rule_26",
-            "accounts/AAMD_rule_12",
-            "accounts/AAMD_rule_9",
-            "accounts/AAMD_rule_1",
-            "accounts/AAMD_rule_7",
+            "accounts/AA_rule_17", "accounts/AA_rule_9", "accounts/AA_rule_10", "accounts/AA_rule_8",
+            "accounts/AA_rule_6", "accounts/AA_rule_12", "accounts/AA_rule_14", "accounts/AA_rule_20",
+            "accounts/AA_rule_23", "accounts/AA_rule_25", "accounts/AA_rule_26", "accounts/AAMD_rule_12",
+            "accounts/AAMD_rule_9", "accounts/AAMD_rule_1", "accounts/AAMD_rule_7",
 
             "insolvency/3.10", "insolvency/4.13", "insolvency/4.20_rule_2", "insolvency/4.31", "insolvency/4.33",
             "insolvency/4.35", "insolvency/4.38", "insolvency/4.40", "insolvency/4.43", "insolvency/WU15(Scot)",
@@ -110,8 +98,8 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
             "insolvency/2.20B(Scot)_rule_2", "insolvency/2.19B(Scot)", "insolvency/2.21B(Scot)",
             "insolvency/2.22B(Scot)", "insolvency/2.23B(Scot)", "insolvency/AM21(Scot)", "insolvency/2.24B(Scot)",
             "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
-"insolvency/2.26B(Scot)",
-            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1","insolvency/1.3(Scot)_rule_2",
+            "insolvency/2.26B(Scot)",
+            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1", "insolvency/1.3(Scot)_rule_2",
             "insolvency/1.4(Scot)", "insolvency/2.2(Scot)", "insolvency/2.12(Scot)", "insolvency/2.26B(Scot)",
             "insolvency/2.27B(Scot)", "insolvency/2.29B(Scot)", "insolvency/2.30B(Scot)", "insolvency/12.1",
             "insolvency/AM15(Scot)", "insolvency/AM23(Scot)", "insolvency/NCOP", "insolvency/RM01(Scot)",
@@ -133,6 +121,8 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
 
     @ParameterizedTest(name = "[{index}] {0}/{1}/{2}")
     @ArgumentsSource(IntegrationDataGenerator.class)
+    @EnabledIfEnvironmentVariable(disabledReason = "Disabled for normal builds", named = "RUN_BULK_TEST",
+            matches = "^(1|true|TRUE)$")
     void shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream(String category, String formType,
             String entityId, String delta, String expectedRequestBody) throws Exception {
         doShouldConsumeFilingHistoryDeltaTopicAndProcessDelta(delta, expectedRequestBody);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDateTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDateTest.java
@@ -95,6 +95,29 @@ class FormatDateTest {
     }
 
     @Test
+    void shouldNotTransformSourceNodeValueIfNull() {
+        // given
+
+        ObjectNode source = MAPPER.createObjectNode();
+        source.putObject("original_values")
+                .put("change_date", (String) null);
+        ObjectNode actual = source.deepCopy();
+
+        ObjectNode expected = MAPPER.createObjectNode();
+        expected.putObject("original_values")
+                .put("change_date", (String) null);
+        expected
+                .putObject("data")
+                .put("action_date", (String) null);
+        // when
+        formatDate.transform(source, actual, "data.action_date", List.of("original_values.change_date"),
+                Map.of());
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
     void shouldThrowNonRetryableExceptionWhenSourceNodeValueCannotBeParsed() {
         // given
         ObjectNode source = MAPPER.createObjectNode();

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDateTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/FormatDateTest.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.filinghistory.consumer.transformrules.functions;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -10,9 +11,11 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import uk.gov.companieshouse.filinghistory.consumer.exception.NonRetryableException;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.TransformerTestingUtils;
 
 class FormatDateTest {
@@ -66,6 +69,45 @@ class FormatDateTest {
 
         // then
         assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldNotTransformSourceNodeValueIfAlreadyInCorrectFormatAndSetOnOutputNode() {
+        // given
+
+        ObjectNode source = MAPPER.createObjectNode();
+        source.putObject("original_values")
+                .put("change_date", "2016-07-02T11:17:16Z");
+        ObjectNode actual = source.deepCopy();
+
+        ObjectNode expected = MAPPER.createObjectNode();
+        expected.putObject("original_values")
+                .put("change_date", "2016-07-02T11:17:16Z");
+        expected
+                .putObject("data")
+                .put("action_date", "2016-07-02T11:17:16Z");
+        // when
+        formatDate.transform(source, actual, "data.action_date", List.of("original_values.change_date"),
+                Map.of());
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldThrowNonRetryableExceptionWhenSourceNodeValueCannotBeParsed() {
+        // given
+        ObjectNode source = MAPPER.createObjectNode();
+        source.putObject("original_values")
+                .put("change_date", "non date text");
+        ObjectNode actual = source.deepCopy();
+
+        // when
+        Executable executable = () -> formatDate.transform(source, actual, "data.action_date",
+                List.of("original_values.change_date"), Map.of());
+
+        // then
+        assertThrows(NonRetryableException.class, executable);
     }
 
     @ParameterizedTest(name = "Map [{0}] to [{1}]")

--- a/src/test/resources/data/capital/EW05RSS_delta.json
+++ b/src/test/resources/data/capital/EW05RSS_delta.json
@@ -1,0 +1,18 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20160728085254",
+      "form_type": "EW05RSS",
+      "description": "Register snapshot for EW05",
+      "barcode": "X5C72WD5",
+      "document_id": "000X5C72WD56351",
+      "company_number": "10265867",
+      "entity_id": "3153889070",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20211029142043360560"
+}

--- a/src/test/resources/data/capital/EW05RSS_request_body.json
+++ b/src/test/resources/data/capital/EW05RSS_request_body.json
@@ -1,0 +1,27 @@
+{
+  "external_data": {
+    "transaction_id": "MzE1Mzg4OTA3MHNhbHQ",
+    "category": "capital",
+    "date": "2016-07-28T08:52:54Z",
+    "description": "members-register-information-on-withdrawal-from-the-public-register",
+    "description_values": {
+      "date": "2016-07-28T08:52:54Z"
+    },
+    "links": {
+      "self": "/company/10265867/filing-history/MzE1Mzg4OTA3MHNhbHQ"
+    },
+    "subcategory": "register",
+    "type": "EW05RSS",
+    "barcode": "X5C72WD5"
+  },
+  "internal_data": {
+    "company_number": "10265867",
+    "document_id": "000X5C72WD56351",
+    "entity_id": "3153889070",
+    "original_description": "Register snapshot for EW05",
+    "updated_by": "context_id",
+    "transaction_kind": "top-level",
+    "parent_entity_id": "",
+    "delta_at": "20211029142043360560"
+  }
+}


### PR DESCRIPTION
## Describe the changes

* Added a check to see if the source text is already correctly formatted
* Updated the integration tests to include an example where double transformation could occur
* Added a guard to stop bulk integration tests being run in normal builds
* Updated the readme to add details of the environment variable, `RUN_BULK_TEST` used to guard the bulk tests
* Updated POM to use Spring Boot 3.2.4

### Related Jira tickets
[DSND-2503](https://companieshouse.atlassian.net/browse/DSND-2503)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [x] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2503]: https://companieshouse.atlassian.net/browse/DSND-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ