### PR TITLE
DSND-2515: Fix annotation transformation where substitution is treated as field name

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.1</structured-logging.version>
     <sdk-manager-java.version>3.0.3</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.97</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.101</private-api-sdk-java.version>
     <kafka-models.version>3.0.4</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformer.java
@@ -12,6 +12,9 @@ public class AnnotationTransformer implements Transformer {
     @Override
     public void transform(JsonNode source, ObjectNode outputNode, String field, List<String> arguments,
                           Map<String, String> contextValue) {
+        String[] fields = field.split("\\.");
+        String finalField = fields[fields.length - 1];
 
+        outputNode.put(finalField, arguments.getFirst());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformer.java
@@ -1,0 +1,17 @@
+package uk.gov.companieshouse.filinghistory.consumer.transformrules.functions;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnotationTransformer implements Transformer {
+
+    @Override
+    public void transform(JsonNode source, ObjectNode outputNode, String field, List<String> arguments,
+                          Map<String, String> contextValue) {
+
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactory.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactory.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 public class TransformerFactory {
 
     private final AddressCase addressCase;
+    private final AnnotationTransformer annotationTransformer;
     private final FormatDate formatDate;
     private final SentenceCase sentenceCase;
     private final TitleCase titleCase;
@@ -13,10 +14,11 @@ public class TransformerFactory {
 
     private final ProcessCapital processCapital;
 
-    public TransformerFactory(AddressCase addressCase, FormatDate formatDate,
-            SentenceCase sentenceCase, TitleCase titleCase, ReplaceProperty replaceProperty,
-            ProcessCapital processCapital) {
+    public TransformerFactory(AddressCase addressCase, AnnotationTransformer annotationTransformer, FormatDate formatDate,
+                              SentenceCase sentenceCase, TitleCase titleCase, ReplaceProperty replaceProperty,
+                              ProcessCapital processCapital) {
         this.addressCase = addressCase;
+        this.annotationTransformer = annotationTransformer;
         this.formatDate = formatDate;
         this.sentenceCase = sentenceCase;
         this.titleCase = titleCase;
@@ -27,6 +29,7 @@ public class TransformerFactory {
     public Transformer mapTransformer(String function) {
         return switch (function) {
             case "address_case" -> addressCase;
+            case "annotation" -> annotationTransformer;
             case "bson_date" -> formatDate;
             case "sentence_case" -> sentenceCase;
             case "title_case" -> titleCase;

--- a/src/main/resources/transform_rules.yml
+++ b/src/main/resources/transform_rules.yml
@@ -8824,8 +8824,8 @@
       type: ANNOTATION
   then:
     set:
-      category: annotation
-      description: annotation
+      category: '[% annotation | annotation %]'
+      description: '[% annotation | annotation %]'
       description_values.description: '[% annotation | sentence_case %]'
 - when:
     eq:

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -67,56 +67,56 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
 
     @ParameterizedTest
     @CsvSource({
-            "annotation/annotation"
+            "annotation/annotation",
 
-//            "annual_return/363s",
-//
-//            "officers/EW01RSS", "officers/TM01",
-//
-//            "capital/SH03", "capital/SH07", "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4",
-//            "capital/SH05", "capital/EW05RSS",
-//
-//            "accounts/AA_rule_17", "accounts/AA_rule_9", "accounts/AA_rule_10", "accounts/AA_rule_8",
-//            "accounts/AA_rule_6", "accounts/AA_rule_12", "accounts/AA_rule_14", "accounts/AA_rule_20",
-//            "accounts/AA_rule_23", "accounts/AA_rule_25", "accounts/AA_rule_26", "accounts/AAMD_rule_12",
-//            "accounts/AAMD_rule_9", "accounts/AAMD_rule_1", "accounts/AAMD_rule_7",
-//
-//            "address/287",
-//
-//            "incorporation/child_transaction/model_articles", "incorporation/child_transaction/newinc",
-//
-//            "insolvency/3.10", "insolvency/4.13", "insolvency/4.20_rule_2", "insolvency/4.31", "insolvency/4.33",
-//            "insolvency/4.35", "insolvency/4.38", "insolvency/4.40", "insolvency/4.43", "insolvency/WU15(Scot)",
-//            "insolvency/WU16(Scot)", "insolvency/WU17(Scot)", "insolvency/WU18(Scot)", "insolvency/4.44",
-//            "insolvency/4.46", "insolvency/4.48", "insolvency/4.51", "incorporation/OE01", "insolvency/4.68_rule_3",
-//            "insolvency/4.20_rule_1", "insolvency/4.68_rule_1", "insolvency/4.69", "insolvency/4.70", "insolvency/4.71",
-//            "insolvency/4.72", "insolvency/4.17(Scot)", "insolvency/4.9(Scot)", "insolvency/C04.2(Scot)",
-//            "insolvency/WU01", "insolvency/WU01(Scot)", "insolvency/C0LIQ", "insolvency/COCOMP_rule_2",
-//            "insolvency/WU07", "insolvency/WU08", "insolvency/WU09", "insolvency/WU11", "insolvency/WU12",
-//            "insolvency/WU14", "insolvency/AM11", "insolvency/2.24B_rule_1", "insolvency/2.24B_rule_2",
-//            "insolvency/2.26B", "insolvency/2.27B", "insolvency/2.28B", "insolvency/2.30B", "insolvency/AM20(Scot)",
-//            "insolvency/2.31B", "insolvency/2.32B", "insolvency/2.33B", "insolvency/2.34B", "insolvency/2.35B_rule_1",
-//            "insolvency/2.35B_rule_2", "insolvency/2.36B", "insolvency/2.38B", "insolvency/2.39B", "insolvency/AM16",
-//            "insolvency/AM17", "insolvency/AM18", "insolvency/2.40B", "insolvency/2.31B(Scot)", "insolvency/2.12B",
-//            "insolvency/AM11(Scot)", "insolvency/AM12", "insolvency/2.16B_rule_1", "insolvency/AM02(Scot)_rule_1",
-//            "insolvency/2.16B_rule_2", "insolvency/2.17B", "insolvency/AM04(Scot)", "insolvency/AM05(Scot)",
-//            "insolvency/2.22B", "insolvency/2.23B", "insolvency/AM08(Scot)", "insolvency/AM07(Scot)",
-//            "insolvency/AM01(Scot)", "insolvency/2.15B_rule_1", "insolvency/2.15B_rule_2", "insolvency/2.16B(Scot)",
-//            "insolvency/AM03(Scot)", "insolvency/2.17B(Scot)", "insolvency/AM09(Scot)", "insolvency/2.16BZ(Scot)",
-//            "insolvency/2.20B(Scot)_rule_2", "insolvency/2.19B(Scot)", "insolvency/2.21B(Scot)",
-//            "insolvency/2.22B(Scot)", "insolvency/2.23B(Scot)", "insolvency/AM21(Scot)", "insolvency/2.24B(Scot)",
-//            "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
-//            "insolvency/2.26B(Scot)",
-//            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1", "insolvency/1.3(Scot)_rule_2",
-//            "insolvency/1.4(Scot)", "insolvency/2.2(Scot)", "insolvency/2.12(Scot)", "insolvency/2.26B(Scot)",
-//            "insolvency/2.27B(Scot)", "insolvency/2.29B(Scot)", "insolvency/2.30B(Scot)", "insolvency/12.1",
-//            "insolvency/AM15(Scot)", "insolvency/AM23(Scot)", "insolvency/NCOP", "insolvency/RM01(Scot)",
-//            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_3", "mortgage/MR02_rule_4",
-//            "mortgage/MR03_rule_4",
-//            "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
-//            "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
-//            "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",
-//            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)"
+            "annual_return/363s",
+
+            "officers/EW01RSS", "officers/TM01",
+
+            "capital/SH03", "capital/SH07", "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4",
+            "capital/SH05", "capital/EW05RSS",
+
+            "accounts/AA_rule_17", "accounts/AA_rule_9", "accounts/AA_rule_10", "accounts/AA_rule_8",
+            "accounts/AA_rule_6", "accounts/AA_rule_12", "accounts/AA_rule_14", "accounts/AA_rule_20",
+            "accounts/AA_rule_23", "accounts/AA_rule_25", "accounts/AA_rule_26", "accounts/AAMD_rule_12",
+            "accounts/AAMD_rule_9", "accounts/AAMD_rule_1", "accounts/AAMD_rule_7",
+
+            "address/287",
+
+            "incorporation/child_transaction/model_articles", "incorporation/child_transaction/newinc",
+
+            "insolvency/3.10", "insolvency/4.13", "insolvency/4.20_rule_2", "insolvency/4.31", "insolvency/4.33",
+            "insolvency/4.35", "insolvency/4.38", "insolvency/4.40", "insolvency/4.43", "insolvency/WU15(Scot)",
+            "insolvency/WU16(Scot)", "insolvency/WU17(Scot)", "insolvency/WU18(Scot)", "insolvency/4.44",
+            "insolvency/4.46", "insolvency/4.48", "insolvency/4.51", "incorporation/OE01", "insolvency/4.68_rule_3",
+            "insolvency/4.20_rule_1", "insolvency/4.68_rule_1", "insolvency/4.69", "insolvency/4.70", "insolvency/4.71",
+            "insolvency/4.72", "insolvency/4.17(Scot)", "insolvency/4.9(Scot)", "insolvency/C04.2(Scot)",
+            "insolvency/WU01", "insolvency/WU01(Scot)", "insolvency/C0LIQ", "insolvency/COCOMP_rule_2",
+            "insolvency/WU07", "insolvency/WU08", "insolvency/WU09", "insolvency/WU11", "insolvency/WU12",
+            "insolvency/WU14", "insolvency/AM11", "insolvency/2.24B_rule_1", "insolvency/2.24B_rule_2",
+            "insolvency/2.26B", "insolvency/2.27B", "insolvency/2.28B", "insolvency/2.30B", "insolvency/AM20(Scot)",
+            "insolvency/2.31B", "insolvency/2.32B", "insolvency/2.33B", "insolvency/2.34B", "insolvency/2.35B_rule_1",
+            "insolvency/2.35B_rule_2", "insolvency/2.36B", "insolvency/2.38B", "insolvency/2.39B", "insolvency/AM16",
+            "insolvency/AM17", "insolvency/AM18", "insolvency/2.40B", "insolvency/2.31B(Scot)", "insolvency/2.12B",
+            "insolvency/AM11(Scot)", "insolvency/AM12", "insolvency/2.16B_rule_1", "insolvency/AM02(Scot)_rule_1",
+            "insolvency/2.16B_rule_2", "insolvency/2.17B", "insolvency/AM04(Scot)", "insolvency/AM05(Scot)",
+            "insolvency/2.22B", "insolvency/2.23B", "insolvency/AM08(Scot)", "insolvency/AM07(Scot)",
+            "insolvency/AM01(Scot)", "insolvency/2.15B_rule_1", "insolvency/2.15B_rule_2", "insolvency/2.16B(Scot)",
+            "insolvency/AM03(Scot)", "insolvency/2.17B(Scot)", "insolvency/AM09(Scot)", "insolvency/2.16BZ(Scot)",
+            "insolvency/2.20B(Scot)_rule_2", "insolvency/2.19B(Scot)", "insolvency/2.21B(Scot)",
+            "insolvency/2.22B(Scot)", "insolvency/2.23B(Scot)", "insolvency/AM21(Scot)", "insolvency/2.24B(Scot)",
+            "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
+            "insolvency/2.26B(Scot)",
+            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1", "insolvency/1.3(Scot)_rule_2",
+            "insolvency/1.4(Scot)", "insolvency/2.2(Scot)", "insolvency/2.12(Scot)", "insolvency/2.26B(Scot)",
+            "insolvency/2.27B(Scot)", "insolvency/2.29B(Scot)", "insolvency/2.30B(Scot)", "insolvency/12.1",
+            "insolvency/AM15(Scot)", "insolvency/AM23(Scot)", "insolvency/NCOP", "insolvency/RM01(Scot)",
+            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_3", "mortgage/MR02_rule_4",
+            "mortgage/MR03_rule_4",
+            "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
+            "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
+            "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",
+            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)"
     })
     void shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromCSV(final String prefix) throws Exception {
         final String delta = IOUtils.resourceToString("/data/%s_delta.json".formatted(prefix), StandardCharsets.UTF_8);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -67,56 +67,56 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
 
     @ParameterizedTest
     @CsvSource({
-            "annotation/annotation",
+            "annotation/annotation"
 
-            "annual_return/363s",
-
-            "officers/EW01RSS", "officers/TM01",
-
-            "capital/SH03", "capital/SH07", "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4",
-            "capital/SH05", "capital/EW05RSS",
-
-            "accounts/AA_rule_17", "accounts/AA_rule_9", "accounts/AA_rule_10", "accounts/AA_rule_8",
-            "accounts/AA_rule_6", "accounts/AA_rule_12", "accounts/AA_rule_14", "accounts/AA_rule_20",
-            "accounts/AA_rule_23", "accounts/AA_rule_25", "accounts/AA_rule_26", "accounts/AAMD_rule_12",
-            "accounts/AAMD_rule_9", "accounts/AAMD_rule_1", "accounts/AAMD_rule_7",
-
-            "address/287",
-
-            "incorporation/child_transaction/model_articles", "incorporation/child_transaction/newinc",
-
-            "insolvency/3.10", "insolvency/4.13", "insolvency/4.20_rule_2", "insolvency/4.31", "insolvency/4.33",
-            "insolvency/4.35", "insolvency/4.38", "insolvency/4.40", "insolvency/4.43", "insolvency/WU15(Scot)",
-            "insolvency/WU16(Scot)", "insolvency/WU17(Scot)", "insolvency/WU18(Scot)", "insolvency/4.44",
-            "insolvency/4.46", "insolvency/4.48", "insolvency/4.51", "incorporation/OE01", "insolvency/4.68_rule_3",
-            "insolvency/4.20_rule_1", "insolvency/4.68_rule_1", "insolvency/4.69", "insolvency/4.70", "insolvency/4.71",
-            "insolvency/4.72", "insolvency/4.17(Scot)", "insolvency/4.9(Scot)", "insolvency/C04.2(Scot)",
-            "insolvency/WU01", "insolvency/WU01(Scot)", "insolvency/C0LIQ", "insolvency/COCOMP_rule_2",
-            "insolvency/WU07", "insolvency/WU08", "insolvency/WU09", "insolvency/WU11", "insolvency/WU12",
-            "insolvency/WU14", "insolvency/AM11", "insolvency/2.24B_rule_1", "insolvency/2.24B_rule_2",
-            "insolvency/2.26B", "insolvency/2.27B", "insolvency/2.28B", "insolvency/2.30B", "insolvency/AM20(Scot)",
-            "insolvency/2.31B", "insolvency/2.32B", "insolvency/2.33B", "insolvency/2.34B", "insolvency/2.35B_rule_1",
-            "insolvency/2.35B_rule_2", "insolvency/2.36B", "insolvency/2.38B", "insolvency/2.39B", "insolvency/AM16",
-            "insolvency/AM17", "insolvency/AM18", "insolvency/2.40B", "insolvency/2.31B(Scot)", "insolvency/2.12B",
-            "insolvency/AM11(Scot)", "insolvency/AM12", "insolvency/2.16B_rule_1", "insolvency/AM02(Scot)_rule_1",
-            "insolvency/2.16B_rule_2", "insolvency/2.17B", "insolvency/AM04(Scot)", "insolvency/AM05(Scot)",
-            "insolvency/2.22B", "insolvency/2.23B", "insolvency/AM08(Scot)", "insolvency/AM07(Scot)",
-            "insolvency/AM01(Scot)", "insolvency/2.15B_rule_1", "insolvency/2.15B_rule_2", "insolvency/2.16B(Scot)",
-            "insolvency/AM03(Scot)", "insolvency/2.17B(Scot)", "insolvency/AM09(Scot)", "insolvency/2.16BZ(Scot)",
-            "insolvency/2.20B(Scot)_rule_2", "insolvency/2.19B(Scot)", "insolvency/2.21B(Scot)",
-            "insolvency/2.22B(Scot)", "insolvency/2.23B(Scot)", "insolvency/AM21(Scot)", "insolvency/2.24B(Scot)",
-            "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
-            "insolvency/2.26B(Scot)",
-            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1", "insolvency/1.3(Scot)_rule_2",
-            "insolvency/1.4(Scot)", "insolvency/2.2(Scot)", "insolvency/2.12(Scot)", "insolvency/2.26B(Scot)",
-            "insolvency/2.27B(Scot)", "insolvency/2.29B(Scot)", "insolvency/2.30B(Scot)", "insolvency/12.1",
-            "insolvency/AM15(Scot)", "insolvency/AM23(Scot)", "insolvency/NCOP", "insolvency/RM01(Scot)",
-            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_3", "mortgage/MR02_rule_4",
-            "mortgage/MR03_rule_4",
-            "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
-            "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
-            "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",
-            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)"
+//            "annual_return/363s",
+//
+//            "officers/EW01RSS", "officers/TM01",
+//
+//            "capital/SH03", "capital/SH07", "capital/SH01", "capital/SH02_rule_2", "capital/SH04_rule_4",
+//            "capital/SH05", "capital/EW05RSS",
+//
+//            "accounts/AA_rule_17", "accounts/AA_rule_9", "accounts/AA_rule_10", "accounts/AA_rule_8",
+//            "accounts/AA_rule_6", "accounts/AA_rule_12", "accounts/AA_rule_14", "accounts/AA_rule_20",
+//            "accounts/AA_rule_23", "accounts/AA_rule_25", "accounts/AA_rule_26", "accounts/AAMD_rule_12",
+//            "accounts/AAMD_rule_9", "accounts/AAMD_rule_1", "accounts/AAMD_rule_7",
+//
+//            "address/287",
+//
+//            "incorporation/child_transaction/model_articles", "incorporation/child_transaction/newinc",
+//
+//            "insolvency/3.10", "insolvency/4.13", "insolvency/4.20_rule_2", "insolvency/4.31", "insolvency/4.33",
+//            "insolvency/4.35", "insolvency/4.38", "insolvency/4.40", "insolvency/4.43", "insolvency/WU15(Scot)",
+//            "insolvency/WU16(Scot)", "insolvency/WU17(Scot)", "insolvency/WU18(Scot)", "insolvency/4.44",
+//            "insolvency/4.46", "insolvency/4.48", "insolvency/4.51", "incorporation/OE01", "insolvency/4.68_rule_3",
+//            "insolvency/4.20_rule_1", "insolvency/4.68_rule_1", "insolvency/4.69", "insolvency/4.70", "insolvency/4.71",
+//            "insolvency/4.72", "insolvency/4.17(Scot)", "insolvency/4.9(Scot)", "insolvency/C04.2(Scot)",
+//            "insolvency/WU01", "insolvency/WU01(Scot)", "insolvency/C0LIQ", "insolvency/COCOMP_rule_2",
+//            "insolvency/WU07", "insolvency/WU08", "insolvency/WU09", "insolvency/WU11", "insolvency/WU12",
+//            "insolvency/WU14", "insolvency/AM11", "insolvency/2.24B_rule_1", "insolvency/2.24B_rule_2",
+//            "insolvency/2.26B", "insolvency/2.27B", "insolvency/2.28B", "insolvency/2.30B", "insolvency/AM20(Scot)",
+//            "insolvency/2.31B", "insolvency/2.32B", "insolvency/2.33B", "insolvency/2.34B", "insolvency/2.35B_rule_1",
+//            "insolvency/2.35B_rule_2", "insolvency/2.36B", "insolvency/2.38B", "insolvency/2.39B", "insolvency/AM16",
+//            "insolvency/AM17", "insolvency/AM18", "insolvency/2.40B", "insolvency/2.31B(Scot)", "insolvency/2.12B",
+//            "insolvency/AM11(Scot)", "insolvency/AM12", "insolvency/2.16B_rule_1", "insolvency/AM02(Scot)_rule_1",
+//            "insolvency/2.16B_rule_2", "insolvency/2.17B", "insolvency/AM04(Scot)", "insolvency/AM05(Scot)",
+//            "insolvency/2.22B", "insolvency/2.23B", "insolvency/AM08(Scot)", "insolvency/AM07(Scot)",
+//            "insolvency/AM01(Scot)", "insolvency/2.15B_rule_1", "insolvency/2.15B_rule_2", "insolvency/2.16B(Scot)",
+//            "insolvency/AM03(Scot)", "insolvency/2.17B(Scot)", "insolvency/AM09(Scot)", "insolvency/2.16BZ(Scot)",
+//            "insolvency/2.20B(Scot)_rule_2", "insolvency/2.19B(Scot)", "insolvency/2.21B(Scot)",
+//            "insolvency/2.22B(Scot)", "insolvency/2.23B(Scot)", "insolvency/AM21(Scot)", "insolvency/2.24B(Scot)",
+//            "insolvency/AM25(Scot)", "insolvency/2.25B(Scot)", "insolvency/AM22(Scot)",
+//            "insolvency/2.26B(Scot)",
+//            "insolvency/1(Scot)", "insolvency/1.3(Scot)_rule_1", "insolvency/1.3(Scot)_rule_2",
+//            "insolvency/1.4(Scot)", "insolvency/2.2(Scot)", "insolvency/2.12(Scot)", "insolvency/2.26B(Scot)",
+//            "insolvency/2.27B(Scot)", "insolvency/2.29B(Scot)", "insolvency/2.30B(Scot)", "insolvency/12.1",
+//            "insolvency/AM15(Scot)", "insolvency/AM23(Scot)", "insolvency/NCOP", "insolvency/RM01(Scot)",
+//            "mortgage/MR01_rule_4", "mortgage/MR01_rule_5", "mortgage/MR02_rule_3", "mortgage/MR02_rule_4",
+//            "mortgage/MR03_rule_4",
+//            "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
+//            "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
+//            "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",
+//            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)"
     })
     void shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromCSV(final String prefix) throws Exception {
         final String delta = IOUtils.resourceToString("/data/%s_delta.json".formatted(prefix), StandardCharsets.UTF_8);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/TransformerTestingUtils.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/TransformerTestingUtils.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.AddressCase;
+import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.AnnotationTransformer;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.CapitalCaptor;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.FormatDate;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.functions.FormatNumber;
@@ -29,9 +30,10 @@ public class TransformerTestingUtils {
     private static final ProcessCapital PROCESS_CAPITAL = new ProcessCapital(MAPPER,
             new CapitalCaptor(MAPPER, new FormatNumber(), new FormatDate(MAPPER)));
     private static final AddressCase ADDRESS_CASE = new AddressCase(MAPPER, TITLE_CASE);
+    private static final AnnotationTransformer ANNOTATION_TRANSFORMER = new AnnotationTransformer();
 
-    private static final TransformerFactory TRANSFORMER_FACTORY = new TransformerFactory(ADDRESS_CASE, BSON_DATE,
-            SENTENCE_CASE, TITLE_CASE, REPLACE_PROPERTY, PROCESS_CAPITAL);
+    private static final TransformerFactory TRANSFORMER_FACTORY = new TransformerFactory(ADDRESS_CASE,
+            ANNOTATION_TRANSFORMER, BSON_DATE, SENTENCE_CASE, TITLE_CASE, REPLACE_PROPERTY, PROCESS_CAPITAL);
 
     private TransformerTestingUtils() {
     }
@@ -70,5 +72,9 @@ public class TransformerTestingUtils {
 
     public static AddressCase getAddressCase() {
         return ADDRESS_CASE;
+    }
+
+    public static AnnotationTransformer getAnnotationTransformer() {
+        return ANNOTATION_TRANSFORMER;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
@@ -1,0 +1,54 @@
+package uk.gov.companieshouse.filinghistory.consumer.transformrules.functions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.filinghistory.consumer.transformrules.TransformerTestingUtils;
+
+class AnnotationTransformerTest {
+
+    private static final ObjectMapper MAPPER = TransformerTestingUtils.getMapper();
+
+    private AnnotationTransformer annotationTransformer;
+
+    @BeforeEach
+    void beforeEach() {
+        annotationTransformer = new AnnotationTransformer();
+    }
+
+    @Test
+    void shouldTransformCategoryFieldToHaveValueOfAnnotation() {
+        // given
+        ObjectNode source = MAPPER.createObjectNode();
+        ObjectNode actual = source.deepCopy();
+
+        ObjectNode expected = MAPPER.createObjectNode();
+        expected.put("category", "annotation");
+
+        // when
+        annotationTransformer.transform(source, actual, "category", List.of("annotation"), Collections.emptyMap());
+
+        // then
+        assertEquals(expected, actual);
+    }
+    @Test
+    void shouldTransformDescriptionFieldToHaveValueOfAnnotation() {
+        // given
+        ObjectNode source = MAPPER.createObjectNode();
+        ObjectNode actual = source.deepCopy();
+
+        ObjectNode expected = MAPPER.createObjectNode();
+        expected.put("description", "annotation");
+
+        // when
+        annotationTransformer.transform(source, actual, "description", List.of("annotation"), Collections.emptyMap());
+
+        // then
+        assertEquals(expected, actual);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
@@ -27,7 +27,7 @@ class AnnotationTransformerTest {
             "category",
             "description"
     })
-    void shouldTransformCategoryFieldToHaveValueOfAnnotation(final String field) {
+    void shouldTransformFieldToHaveValueOfAnnotation(final String field) {
         // given
         ObjectNode source = MAPPER.createObjectNode();
         ObjectNode actual = source.deepCopy();

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/AnnotationTransformerTest.java
@@ -7,7 +7,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import uk.gov.companieshouse.filinghistory.consumer.transformrules.TransformerTestingUtils;
 
 class AnnotationTransformerTest {
@@ -21,32 +22,21 @@ class AnnotationTransformerTest {
         annotationTransformer = new AnnotationTransformer();
     }
 
-    @Test
-    void shouldTransformCategoryFieldToHaveValueOfAnnotation() {
+    @ParameterizedTest
+    @CsvSource({
+            "category",
+            "description"
+    })
+    void shouldTransformCategoryFieldToHaveValueOfAnnotation(final String field) {
         // given
         ObjectNode source = MAPPER.createObjectNode();
         ObjectNode actual = source.deepCopy();
 
         ObjectNode expected = MAPPER.createObjectNode();
-        expected.put("category", "annotation");
+        expected.put(field, "annotation");
 
         // when
-        annotationTransformer.transform(source, actual, "category", List.of("annotation"), Collections.emptyMap());
-
-        // then
-        assertEquals(expected, actual);
-    }
-    @Test
-    void shouldTransformDescriptionFieldToHaveValueOfAnnotation() {
-        // given
-        ObjectNode source = MAPPER.createObjectNode();
-        ObjectNode actual = source.deepCopy();
-
-        ObjectNode expected = MAPPER.createObjectNode();
-        expected.put("description", "annotation");
-
-        // when
-        annotationTransformer.transform(source, actual, "description", List.of("annotation"), Collections.emptyMap());
+        annotationTransformer.transform(source, actual, field, List.of("annotation"), Collections.emptyMap());
 
         // then
         assertEquals(expected, actual);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactoryTest.java
@@ -74,20 +74,10 @@ class TransformerFactoryTest {
         assertInstanceOf(expectedClass, actual);
     }
 
-    @Test
-    void shouldReturnAnnotationTransformer() {
-        // given
-
-        // when
-        Transformer actual = factory.mapTransformer("annotation");
-
-        // then
-        assertInstanceOf(AnnotationTransformer.class, actual);
-    }
-
     private static Stream<Arguments> transformTestArgs() {
         return Stream.of(
                 Arguments.of("address_case", AddressCase.class),
+                Arguments.of("annotation", AnnotationTransformer.class),
                 Arguments.of("bson_date", FormatDate.class),
                 Arguments.of("sentence_case", SentenceCase.class),
                 Arguments.of("title_case", TitleCase.class));

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/transformrules/functions/TransformerFactoryTest.java
@@ -16,6 +16,7 @@ class TransformerFactoryTest {
 
     private TransformerFactory factory;
     private final AddressCase addressCase = TransformerTestingUtils.getAddressCase();
+    private  final AnnotationTransformer annotationTransformer = TransformerTestingUtils.getAnnotationTransformer();
     private final FormatDate formatDate = TransformerTestingUtils.getBsonDate();
     private final SentenceCase sentenceCase = TransformerTestingUtils.getSentenceCase();
     private final TitleCase titleCase = TransformerTestingUtils.getTitleCase();
@@ -24,8 +25,8 @@ class TransformerFactoryTest {
 
     @BeforeEach
     void setUp() {
-        factory = new TransformerFactory(addressCase, formatDate, sentenceCase, titleCase, replaceProperty,
-                processCapital);
+        factory = new TransformerFactory(addressCase, annotationTransformer, formatDate, sentenceCase, titleCase,
+                replaceProperty, processCapital);
     }
 
     @Test
@@ -71,6 +72,17 @@ class TransformerFactoryTest {
 
         // then
         assertInstanceOf(expectedClass, actual);
+    }
+
+    @Test
+    void shouldReturnAnnotationTransformer() {
+        // given
+
+        // when
+        Transformer actual = factory.mapTransformer("annotation");
+
+        // then
+        assertInstanceOf(AnnotationTransformer.class, actual);
     }
 
     private static Stream<Arguments> transformTestArgs() {

--- a/src/test/resources/data/annotation/annotation_request_body.json
+++ b/src/test/resources/data/annotation/annotation_request_body.json
@@ -11,9 +11,9 @@
     "annotations" : [
       {
         "annotation" : "A second filed TM01 was registered on the 05 November 2012",
-        "category" : "A second filed TM01 was registered on the 05 November 2012",
+        "category" : "annotation",
         "date" : "2011-11-26T11:27:55Z",
-        "description" : "A second filed TM01 was registered on the 05 November 2012",
+        "description" : "annotation",
         "description_values" : {
           "description" : "A second filed TM01 was registered on the 05 November 2012"
         },


### PR DESCRIPTION
## Describe the changes
This PR fixes a bug where the description and category fields on the child object were being set to the incorrect value during transformation.

### Related Jira tickets
[DSND-2515](https://companieshouse.atlassian.net/browse/DSND-2515)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2515]: https://companieshouse.atlassian.net/browse/DSND-2515?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ