### PR TITLE
DSND-2579: Fix expected test data empty values

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ services and modules will be started as dependencies of these two):
 To run the tests from the command line use:
 
 ```shell
-HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> PERL_SALT=<perl_salt> RUN_BULK_TEST=1 \
+HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> TRANSACTION_ID_SALT=<perl_salt> RUN_BULK_TEST=1 \
 mvn test -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
 ```
 
@@ -111,7 +111,7 @@ https://companieshouse.atlassian.net/wiki/spaces/TH/pages/4029120676/Harmonia+Te
 the [chs-backend](https://github.com/companieshouse/chs-backend/blob/93494b863fcbb97e99195e54770b30b8ebcd4668/lib/ChsBackend/Roles/Transform.pm#L416)
 repository
 * To run the tests in IntelliJ
-  add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; PERL_SALT=<perl_salt>; RUN_BULK_TEST=1`
+  add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; TRANSACTION_ID_SALT=<perl_salt>; RUN_BULK_TEST=1`
   settings to the Environment Variables section of the run configuration dialog.
 
 ### IMPORTANT


### PR DESCRIPTION
## Describe the changes
* Perl-generated Mongo documents are now deleted after generation to fix the issue of not being found during PUT request generation.
* The Local/Tilt Mongo filing history collection is cleared prior to starting the test run.
* In `PutRequestMatcher`, remove body matching on transaction kind when value is null in the expected document
* `document_id` now populated correctly for resolutions.
* Environment variable `PERL_SALT` changed to `TRANSACTION_ID_SALT`

### Related Jira tickets
[DSND-2579](https://companieshouse.atlassian.net/browse/DSND-2578)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2579]: https://companieshouse.atlassian.net/browse/DSND-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ