### PR TITLE
DSND-2363: Implement transaction kind handling for resolutions without a barcode

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/TransactionKindService.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/TransactionKindService.java
@@ -40,17 +40,14 @@ public class TransactionKindService {
             }
             kindEnum = TransactionKindEnum.ANNOTATION;
 
-        } else if (RES_15.equals(kindCriteria.formType())) {
-            if (StringUtils.isNotBlank(kindCriteria.parentEntityId())) {
+        } else if (formTypeService.isResolutionType(kindCriteria.formType())) {
+            if (StringUtils.isNotBlank(kindCriteria.barcode()) && !RES_15.equals(kindCriteria.formType())) {
+                encodedId = encodeTransactionId(kindCriteria.barcode());
+            } else if (StringUtils.isNotBlank(kindCriteria.parentEntityId())) {
                 encodedId = encodeTransactionId(kindCriteria.parentEntityId());
             } else {
                 encodedId = encodeTransactionId(kindCriteria.entityId());
             }
-            kindEnum = TransactionKindEnum.RESOLUTION;
-            
-        } else if (StringUtils.isNotBlank(kindCriteria.barcode())
-                && formTypeService.isResolutionType(kindCriteria.formType())) {
-            encodedId = encodeTransactionId(kindCriteria.barcode());
             kindEnum = TransactionKindEnum.RESOLUTION;
 
         } else if (!formTypeService.isAssociatedFilingBlockListed(kindCriteria)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -67,9 +67,7 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
 
     @ParameterizedTest
     @CsvSource({
-            "resolution/RES01",
-            "resolution/RES15_top_level",
-            "resolution/RES15_child",
+            "resolution/RES01", "resolution/RES01_no_barcode", "resolution/RES15_top_level", "resolution/RES15_child",
 
             "annotation/annotation",
 

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/TransactionKindServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/TransactionKindServiceTest.java
@@ -63,6 +63,8 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verify(formTypeService).isResolutionType(criteria.formType());
+        verify(formTypeService).isAssociatedFilingBlockListed(criteria);
     }
 
     @Test
@@ -83,6 +85,7 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verifyNoInteractions(formTypeService);
     }
 
     @Test
@@ -103,6 +106,7 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verifyNoInteractions(formTypeService);
     }
 
     @Test
@@ -126,6 +130,7 @@ class TransactionKindServiceTest {
         // then
         assertEquals(expected, actual);
         verify(formTypeService).isResolutionType("RES01");
+        verifyNoMoreInteractions(formTypeService);
     }
 
     @ParameterizedTest
@@ -134,6 +139,8 @@ class TransactionKindServiceTest {
     }, nullValues = {"null"})
     void shouldEncodeEntityIdWhenResolutionButBarcodeBlank(String barcode) {
         // given
+        when(formTypeService.isResolutionType(any())).thenReturn(true);
+
         TransactionKindCriteria criteria = new TransactionKindCriteria(
                 ENTITY_ID,
                 "",
@@ -142,20 +149,22 @@ class TransactionKindServiceTest {
                 barcode);
         TransactionKindResult expected = new TransactionKindResult(
                 ENCODED_ENTITY_ID,
-                TransactionKindEnum.TOP_LEVEL);
+                TransactionKindEnum.RESOLUTION);
 
         // when
         TransactionKindResult actual = kindService.encodeIdByTransactionKind(criteria);
 
         // then
         assertEquals(expected, actual);
-        verify(formTypeService).isAssociatedFilingBlockListed(criteria);
+        verify(formTypeService).isResolutionType(criteria.formType());
         verifyNoMoreInteractions(formTypeService);
     }
 
     @Test
     void shouldEncodeEntityIdWhenRES15() {
         // given
+        when(formTypeService.isResolutionType(any())).thenReturn(true);
+
         TransactionKindCriteria criteria = new TransactionKindCriteria(
                 ENTITY_ID,
                 "",
@@ -171,7 +180,32 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
-        verifyNoInteractions(formTypeService);
+        verify(formTypeService).isResolutionType(criteria.formType());
+        verifyNoMoreInteractions(formTypeService);
+    }
+
+    @Test
+    void shouldEncodeParentEntityIdWhenRES15Child() {
+        // given
+        when(formTypeService.isResolutionType(any())).thenReturn(true);
+
+        TransactionKindCriteria criteria = new TransactionKindCriteria(
+                ENTITY_ID,
+                PARENT_ENTITY_ID,
+                "RES15",
+                "",
+                BARCODE);
+        TransactionKindResult expected = new TransactionKindResult(
+                ENCODED_PARENT_ENTITY_ID,
+                TransactionKindEnum.RESOLUTION);
+
+        // when
+        TransactionKindResult actual = kindService.encodeIdByTransactionKind(criteria);
+
+        // then
+        assertEquals(expected, actual);
+        verify(formTypeService).isResolutionType(criteria.formType());
+        verifyNoMoreInteractions(formTypeService);
     }
 
     @Test
@@ -194,6 +228,7 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verify(formTypeService).isResolutionType(criteria.formType());
         verify(formTypeService).isAssociatedFilingBlockListed(criteria);
     }
 
@@ -217,6 +252,7 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verify(formTypeService).isResolutionType(criteria.formType());
         verify(formTypeService).isAssociatedFilingBlockListed(criteria);
     }
 
@@ -240,6 +276,7 @@ class TransactionKindServiceTest {
 
         // then
         assertEquals(expected, actual);
+        verify(formTypeService).isResolutionType(criteria.formType());
         verify(formTypeService).isAssociatedFilingBlockListed(criteria);
     }
 

--- a/src/test/resources/data/resolution/RES01_no_barcode_delta.json
+++ b/src/test/resources/data/resolution/RES01_no_barcode_delta.json
@@ -1,0 +1,21 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20100224111028",
+      "form_type": "RES01",
+      "description": "ALTER ARTICLES 19/02/2010",
+      "barcode": "",
+      "document_id": "",
+      "company_number": "05424214",
+      "entity_id": "3010144460",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "description_values": {
+        "res_type": "ALTER ARTICLES"
+      },
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20211029142043360560"
+}

--- a/src/test/resources/data/resolution/RES01_no_barcode_request_body.json
+++ b/src/test/resources/data/resolution/RES01_no_barcode_request_body.json
@@ -1,0 +1,36 @@
+{
+  "external_data" : {
+    "transaction_id" : "MzAxMDE0NDQ2MHNhbHQ",
+    "category" : "resolution",
+    "date" : "2010-02-24T11:10:28Z",
+    "description" : "resolution",
+    "description_values" : {
+      "description" : "Resolutions"
+    },
+    "links" : {
+      "self" : "/company/05424214/filing-history/MzAxMDE0NDQ2MHNhbHQ"
+    },
+    "paper_filed" : true,
+    "resolutions" : [
+      {
+        "category" : "incorporation",
+        "description" : "resolution-alteration-articles",
+        "description_values" : {
+          "res_type" : "ALTER ARTICLES"
+        },
+        "subcategory" : "resolution",
+        "type" : "RES01"
+      }
+    ],
+    "type" : "RESOLUTIONS"
+  },
+  "internal_data": {
+    "original_description" : "Resolutions",
+    "company_number" : "05424214",
+    "entity_id": "3010144460",
+    "parent_entity_id": "",
+    "delta_at": "20211029142043360560",
+    "updated_by": "context_id",
+    "transaction_kind": "resolution"
+  }
+}


### PR DESCRIPTION
## Describe the changes
* Resolutions, other than RES15s, without a barcode were incorrectly being sent as top level transactions to the data API.
* This has been fixed by checking for resolution type first then deciding how to encode the ID.

### Related Jira tickets
[DSND-2363](https://companieshouse.atlassian.net/browse/DSND-2363)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2363]: https://companieshouse.atlassian.net/browse/DSND-2363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ