### PR TITLE
DSND2578: Updated README with config for Kafka poling times in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ To run the tests from the command line use:
 
 ```shell
 HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> TRANSACTION_ID_SALT=<perl_salt> RUN_BULK_TEST=1 \
-mvn test -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
+mvn test -Dkafka.polling_duration=1 -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
 ```
 
 _Note:_
@@ -111,8 +111,12 @@ https://companieshouse.atlassian.net/wiki/spaces/TH/pages/4029120676/Harmonia+Te
 the [chs-backend](https://github.com/companieshouse/chs-backend/blob/93494b863fcbb97e99195e54770b30b8ebcd4668/lib/ChsBackend/Roles/Transform.pm#L416)
 repository
 * To run the tests in IntelliJ
-  add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; TRANSACTION_ID_SALT=<perl_salt>; RUN_BULK_TEST=1`
+    *
+    Add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; TRANSACTION_ID_SALT=<perl_salt>; RUN_BULK_TEST=1`
   settings to the Environment Variables section of the run configuration dialog.
+    * Add `-Dkafka.polling_duration=1-` to the system properties. The complete settings should look
+      like
+        * ```-ea -Dkafka.polling_duration=1```
 
 ### IMPORTANT
 


### PR DESCRIPTION
## Describe the changes

Updated README to add  `kafka.polling_duration` can be set locally to speed up integration tests

### Related Jira tickets
[DSND-2578](https://companieshouse.atlassian.net/browse/DSND-2578)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2578]: https://companieshouse.atlassian.net/browse/DSND-2578?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ