### PR TITLE
DSND2578: Added a bulk integration test for deltas that fail in Perl

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ services and modules will be started as dependencies of these two):
 To run the tests from the command line use:
 
 ```shell
-HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> TRANSACTION_ID_SALT=<perl_salt> RUN_BULK_TEST=1 \
-mvn test -Dkafka.polling_duration=1 -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
+HUMAN_LOG=1 KERMIT_PASSWORD=<kermit_password> TRANSACTION_ID_SALT=<perl_salt> RUN_BULK_TEST=1 KAFKA_POLLING_DURATION=1 \
+mvn test -Dtest="ConsumerPositiveComprehensiveIT#shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromStream"
 ```
 
 _Note:_
@@ -112,11 +112,8 @@ the [chs-backend](https://github.com/companieshouse/chs-backend/blob/93494b863fc
 repository
 * To run the tests in IntelliJ
     *
-    Add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; TRANSACTION_ID_SALT=<perl_salt>; RUN_BULK_TEST=1`
+    Add `HUMAN_LOG=1; KERMIT_PASSWORD=<kermit_password>; TRANSACTION_ID_SALT=<perl_salt>; RUN_BULK_TEST=1; KAFKA_POLLING_DURATION=1` \
   settings to the Environment Variables section of the run configuration dialog.
-    * Add `-Dkafka.polling_duration=1-` to the system properties. The complete settings should look
-      like
-        * ```-ea -Dkafka.polling_duration=1```
 
 ### IMPORTANT
 

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkMappingDescriptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkMappingDescriptionIT.java
@@ -1,0 +1,99 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.put;
+import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.KafkaUtils.ERROR_TOPIC;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.KafkaUtils.INVALID_TOPIC;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.KafkaUtils.MAIN_TOPIC;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.KafkaUtils.RETRY_TOPIC;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import java.io.ByteArrayOutputStream;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.avro.reflect.ReflectDatumWriter;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ArgumentsSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import uk.gov.companieshouse.delta.ChsDelta;
+
+@SpringBootTest
+@WireMockTest(httpPort = 8888)
+class BulkMappingDescriptionIT extends AbstractKafkaIT {
+
+    @Autowired
+    private KafkaConsumer<String, byte[]> testConsumer;
+    @Autowired
+    private KafkaProducer<String, byte[]> testProducer;
+    @Autowired
+    private TestConsumerAspect testConsumerAspect;
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @DynamicPropertySource
+    static void props(DynamicPropertyRegistry registry) {
+        registry.add("steps", () -> 1);
+    }
+
+    @BeforeEach
+    public void setup() {
+        testConsumerAspect.resetLatch();
+        testConsumer.poll(KafkaUtils.kafkaPollingDuration());
+    }
+
+    @ParameterizedTest(name = "[{index}] {0}/{1}")
+    @ArgumentsSource(IntegrationDescriptionGenerator.class)
+    @EnabledIfEnvironmentVariable(disabledReason = "Disabled for normal builds", named = "RUN_BULK_TEST",
+            matches = "^(1|true|TRUE)$")
+    void shouldMapDeltaToExpectedDescription(String entityId, String formType, String expectedDescription,
+            String transactionId, String companyNumber, String delta) throws Exception {
+        // given
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        Encoder encoder = EncoderFactory.get().directBinaryEncoder(outputStream, null);
+        DatumWriter<ChsDelta> writer = new ReflectDatumWriter<>(ChsDelta.class);
+        writer.write(new ChsDelta(delta, 0, "context_id", false), encoder);
+
+        final String expectedRequestUri = "/filing-history-data-api/company/%s/filing-history/%s/internal".formatted(
+                companyNumber, transactionId);
+
+        stubFor(put(urlEqualTo(expectedRequestUri))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        // when
+        testProducer.send(new ProducerRecord<>(MAIN_TOPIC, 0, System.currentTimeMillis(),
+                "key", outputStream.toByteArray()));
+        if (!testConsumerAspect.getLatch().await(5L, TimeUnit.SECONDS)) {
+            fail("Timed out waiting for latch");
+        }
+
+        // then
+        ConsumerRecords<?, ?> consumerRecords = KafkaTestUtils.getRecords(testConsumer, Duration.ofMillis(10000L), 1);
+        assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, MAIN_TOPIC)).isOne();
+        assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, RETRY_TOPIC)).isZero();
+        assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
+        assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
+
+        verify(requestMadeFor(new PutRequestDescriptionMatcher(expectedRequestUri, expectedDescription)));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -62,7 +62,7 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
     @BeforeEach
     public void setup() {
         testConsumerAspect.resetLatch();
-        testConsumer.poll(Duration.ofMillis(Integer.getInteger("kafka.polling_duration", 1000)));
+        testConsumer.poll(KafkaUtils.kafkaPollingDuration());
     }
 
     @ParameterizedTest

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/IntegrationDescriptionGenerator.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/IntegrationDescriptionGenerator.java
@@ -1,0 +1,97 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import java.sql.SQLException;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Stream;
+import javax.sql.DataSource;
+import oracle.jdbc.pool.OracleDataSource;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.ArgumentsProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class IntegrationDescriptionGenerator implements ArgumentsProvider {
+
+    private static final Logger logger = LoggerFactory.getLogger(IntegrationDataGenerator.class);
+    private static final String KERMIT_CONNECTION = "jdbc:oracle:thin:KERMITUNIX2/%s@//chd-chipsdb:1521/chipsdev"
+            .formatted(System.getenv("KERMIT_PASSWORD"));
+
+    private static final String FIND_ALL_DESCRIPTIONS = """
+            SELECT
+                id,
+                entity_id,
+                form_type,
+                description,
+                (
+                    SELECT
+                        pkg_chs_get_data.f_get_one_transaction_api(entity_id, '29-OCT-21 14.20.43.360560000')
+                    FROM
+                        dual
+                ) AS delta
+            FROM
+                capdevjco2.fh_extracted_test_data
+            WHERE
+                    loaded_into_chips_kermit = 'Y'
+                AND id IS NOT NULL
+                AND entity_id NOT IN ( 3153600699, 3168588719, 3178873249, 3180140883, 3183442513,
+                                       3188166405, 3188752683, 3246675970, 3153598406, 3157961596,
+                                       3160750562, 3178873198, 3181240723, 3181240912, 3182858493,
+                                       3183361204, 3183887704 )
+            """;
+
+    private record DeltaDescription(String id,
+                                    String entityId,
+                                    String formType,
+                                    String description,
+                                    String delta) {
+
+    }
+
+    @Override
+    public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
+
+        try {
+            JdbcTemplate jdbcTemplate = new JdbcTemplate(chipsSource());
+
+            Queue<Arguments> queue = new ConcurrentLinkedQueue<>();
+            jdbcTemplate.query(FIND_ALL_DESCRIPTIONS, (rs, rowNum) -> new DeltaDescription(
+                            rs.getString("id"),
+                            rs.getString("entity_id"),
+                            rs.getString("form_type"),
+                            rs.getString("description").trim(),
+                            rs.getString("delta")))
+                    .forEach(deltaDescription -> {
+
+                        if (deltaDescription.delta() != null) {
+
+                            DocumentContext delta = JsonPath.parse(deltaDescription.delta());
+                            String companyNumber = delta.read("$.filing_history[0].company_number");
+
+                            queue.add(
+                                    Arguments.of(deltaDescription.entityId(), deltaDescription.formType(),
+                                            deltaDescription.description(), deltaDescription.id(), companyNumber,
+                                            deltaDescription.delta()));
+
+                        } else {
+                            logger.warn("No delta JSON found for transaction {}", deltaDescription.entityId());
+                        }
+                    });
+            logger.info("Done");
+            return queue.stream();
+        } catch (SQLException e) {
+            logger.error("Failed accessing the CHIPS database", e);
+            throw new RuntimeException(e);
+        }
+    }
+
+    public DataSource chipsSource() throws SQLException {
+        OracleDataSource dataSource = new OracleDataSource();
+        dataSource.setURL(KERMIT_CONNECTION);
+        return dataSource;
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/KafkaUtils.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/KafkaUtils.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.filinghistory.consumer.kafka;
 
+import java.time.Duration;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
@@ -19,5 +20,11 @@ final class KafkaUtils {
             count++;
         }
         return count;
+    }
+
+    static Duration kafkaPollingDuration() {
+        String kafkaPollingDuration = System.getenv().containsKey("KAFKA_POLLING_DURATION") ?
+                System.getenv("KAFKA_POLLING_DURATION") : "1000";
+        return Duration.ofMillis(Long.parseLong(kafkaPollingDuration));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PutRequestDescriptionMatcher.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PutRequestDescriptionMatcher.java
@@ -1,0 +1,61 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
+
+public class PutRequestDescriptionMatcher implements ValueMatcher<Request> {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper()
+            .setSerializationInclusion(Include.NON_EMPTY)
+            .registerModule(new JavaTimeModule());
+
+    private final String expectedUrl;
+    private final String expectedDescription;
+
+    public PutRequestDescriptionMatcher(String expectedUrl, String expectedDescription) {
+        this.expectedUrl = expectedUrl;
+        this.expectedDescription = expectedDescription;
+    }
+
+    @Override
+    public MatchResult match(Request value) {
+        return MatchResult.aggregate(
+                matchUrl(value.getUrl()),
+                matchMethod(value.getMethod()),
+                matchBody(value.getBodyAsString())
+        );
+    }
+
+    private MatchResult matchUrl(String actualUrl) {
+        return MatchResult.of(expectedUrl.equals(actualUrl));
+    }
+
+    private MatchResult matchMethod(RequestMethod actualMethod) {
+        return MatchResult.of(RequestMethod.PUT.equals(actualMethod));
+    }
+
+    private MatchResult matchBody(String actualBody) {
+
+        try {
+            InternalFilingHistoryApi actual = MAPPER.readValue(actualBody, InternalFilingHistoryApi.class);
+            String actualDescription = actual.getExternalData().getDescription();
+
+            MatchResult result = MatchResult.of(expectedDescription.equals(actualDescription));
+            if (!result.isExactMatch()) {
+                System.out.printf("%nExpected description: [%s]%n", expectedDescription);
+                System.out.printf("%nActual description:   [%s]", actualDescription);
+            }
+            return result;
+        } catch (JsonProcessingException ex) {
+            return MatchResult.of(false);
+        }
+    }
+}
+


### PR DESCRIPTION
## Describe the changes

* Added `BulkMappingDescriptionIT` to check transformations that cannot be performed in
  `ConsumerPositiveComprehensiveIT` due to issues with the Perl code
* Matches on the expected descriptions values from 2024-01-17-data-sync-test-data-v2.xlsx
* Refactored the Kafka polling timeout to use the environment variable `KAFKA_POLLING_DURATION`
  and put the duration calculation in `KafkaUtils`
* Excluded deltas that are known to fail in Perl in integration tests
* Reformatted queries

### Related Jira tickets
[DSND-2611](https://companieshouse.atlassian.net/browse/DSND-2611)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2611]: https://companieshouse.atlassian.net/browse/DSND-2611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ