### PR TITLE
DSND-2600: Change delete process to use entity_id rather than transaction_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ within `kafka/ConsumerPositiveComprehensiveIT.java` to cover as many of
 the [transformation rules](https://github.com/companieshouse/filing-history-delta-consumer/blob/df6ee016f916e303474034ace5c3cc346b50d441/src/main/resources/transform_rules.yml)
 as possible.
 
+### Running Comprehensive CSV ITests via Intellij
+This will speed up the running of the comprehensive tests for `shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromCSV`.
+
+1. Run the test using Intellij and then immediately stop the test running so that it appears in run configurations at the top right.
+2. Click on the 3 vertical dots and edit the configuration.
+3. Add `KAFKA_POLLING_DURATION=1` to the "Environment variables" box.
+4. Apply and OK.
+5. Run the tests.
+
 ### Running manual bulk integration tests
 
 The bulk integration tests use a set of test deltas, derived from the Live CHIPS database, to check

--- a/pom.xml
+++ b/pom.xml
@@ -17,13 +17,13 @@
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
     <spring.boot.version>3.2.5</spring.boot.version>
-    <jib-maven-plugin.version>3.4.0</jib-maven-plugin.version>
+    <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
     <test-containers.version>1.19.7</test-containers.version>
     <maven-surefire.version>3.2.5</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
     <commons-text.version>1.12.0</commons-text.version>
-    <wiremock.version>3.5.3</wiremock.version>
+    <wiremock.version>3.5.4</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClient.java
@@ -41,11 +41,11 @@ public class FilingHistoryApiClient {
         }
     }
 
-    public void deleteFilingHistory(String transactionId) {
+    public void deleteFilingHistory(String entityId) {
         InternalApiClient client = internalApiClientFactory.get();
         client.getHttpClient().setRequestId(DataMapHolder.getRequestId());
 
-        final String formattedUri = DELETE_REQUEST_URI.formatted(transactionId);
+        final String formattedUri = DELETE_REQUEST_URI.formatted(entityId);
 
         try {
             client.privateDeltaResourceHandler()

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaService.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaService.java
@@ -12,19 +12,14 @@ public class DeleteDeltaService implements DeltaService {
     private final FilingHistoryDeltaDeserialiser deserialiser;
     private final FilingHistoryApiClient apiClient;
 
-    private final TransactionKindService transactionKindService;
-
-    public DeleteDeltaService(FilingHistoryDeltaDeserialiser deserialiser, FilingHistoryApiClient apiClient,
-            TransactionKindService transactionKindService) {
+    public DeleteDeltaService(FilingHistoryDeltaDeserialiser deserialiser, FilingHistoryApiClient apiClient) {
         this.deserialiser = deserialiser;
         this.apiClient = apiClient;
-        this.transactionKindService = transactionKindService;
     }
 
     @Override
     public void process(ChsDelta delta) {
         FilingHistoryDeleteDelta deleteDelta = deserialiser.deserialiseFilingHistoryDeleteDelta(delta.getData());
-        String transactionId = transactionKindService.encodeTransactionId(deleteDelta.getEntityId());
-        apiClient.deleteFilingHistory(transactionId);
+        apiClient.deleteFilingHistory(deleteDelta.getEntityId());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClientTest.java
@@ -31,6 +31,7 @@ class FilingHistoryApiClientTest {
     private static final String PRE_FORMAT_DELETE_URI = "/filing-history-data-api/filing-history/%s/internal";
     private static final String COMPANY_NUMBER = "12345678";
     private static final String TRANSACTION_ID = "MzA0Mzk3MjY3NXNhbHQ";
+    private static final String ENTITY_ID = "1234567891";
     private static final String REQUEST_ID = "request_id";
 
     @InjectMocks
@@ -151,10 +152,10 @@ class FilingHistoryApiClientTest {
         when(privateDeltaResourceHandler.deleteFilingHistory(anyString())).thenReturn(privateFilingHistoryDelete);
 
         DataMapHolder.get().requestId(REQUEST_ID);
-        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(TRANSACTION_ID);
+        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(ENTITY_ID);
 
         // when
-        filingHistoryApiClient.deleteFilingHistory(TRANSACTION_ID);
+        filingHistoryApiClient.deleteFilingHistory(ENTITY_ID);
 
         // then
         verify(apiClient).setRequestId(REQUEST_ID);
@@ -176,10 +177,10 @@ class FilingHistoryApiClientTest {
         when(privateFilingHistoryDelete.execute()).thenThrow(exceptionClass);
 
         DataMapHolder.get().requestId(REQUEST_ID);
-        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(TRANSACTION_ID);
+        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(ENTITY_ID);
 
         // when
-        filingHistoryApiClient.deleteFilingHistory(TRANSACTION_ID);
+        filingHistoryApiClient.deleteFilingHistory(ENTITY_ID);
 
         // then
         verify(apiClient).setRequestId(REQUEST_ID);
@@ -201,10 +202,10 @@ class FilingHistoryApiClientTest {
         when(privateFilingHistoryDelete.execute()).thenThrow(exceptionClass);
 
         DataMapHolder.get().requestId(REQUEST_ID);
-        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(TRANSACTION_ID);
+        final String expectedUri = PRE_FORMAT_DELETE_URI.formatted(ENTITY_ID);
 
         // when
-        filingHistoryApiClient.deleteFilingHistory(TRANSACTION_ID);
+        filingHistoryApiClient.deleteFilingHistory(ENTITY_ID);
 
         // then
         verify(apiClient).setRequestId(REQUEST_ID);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaServiceTest.java
@@ -18,16 +18,14 @@ import uk.gov.companieshouse.filinghistory.consumer.serdes.FilingHistoryDeltaDes
 class DeleteDeltaServiceTest {
 
     private static final String ENTITY_ID = "entityId";
-    private static final String ENCODED_ID = "encodedId";
     private static final String DELTA_DATA = "delta";
+
     @InjectMocks
     private DeleteDeltaService service;
     @Mock
     private FilingHistoryDeltaDeserialiser deserialiser;
     @Mock
     private FilingHistoryApiClient apiClient;
-    @Mock
-    private TransactionKindService transactionKindService;
     @Mock
     private FilingHistoryDeleteDelta delta;
 
@@ -36,7 +34,6 @@ class DeleteDeltaServiceTest {
         // given
         when(deserialiser.deserialiseFilingHistoryDeleteDelta(any())).thenReturn(delta);
         when(delta.getEntityId()).thenReturn(ENTITY_ID);
-        when(transactionKindService.encodeTransactionId(any())).thenReturn(ENCODED_ID);
 
         ChsDelta chsDelta = new ChsDelta(DELTA_DATA, 0, "contextId", true);
 
@@ -45,7 +42,6 @@ class DeleteDeltaServiceTest {
 
         // then
         verify(deserialiser).deserialiseFilingHistoryDeleteDelta(DELTA_DATA);
-        verify(transactionKindService).encodeTransactionId(ENTITY_ID);
-        verify(apiClient).deleteFilingHistory(ENCODED_ID);
+        verify(apiClient).deleteFilingHistory(ENTITY_ID);
     }
 }

--- a/src/test/resources/data/officers/RP04LLPSC04_request_body.json
+++ b/src/test/resources/data/officers/RP04LLPSC04_request_body.json
@@ -7,7 +7,7 @@
     "date": "2020-01-27T15:32:26Z",
     "description": "second-filing-change-details-of-a-person-with-significant-control-limited-liability-partnership",
     "description_values": {
-      "psc_name": "Tester testing testname"
+      "psc_name": "Tester Testing Testname"
     },
     "links": {
       "self": "/company/OC429371/filing-history/MzI1NTY0OTM3M3NhbHQ"

--- a/src/test/resources/data/officers/RP04LLPSC05_request_body.json
+++ b/src/test/resources/data/officers/RP04LLPSC05_request_body.json
@@ -7,7 +7,7 @@
     "date": "2020-01-23T15:27:14Z",
     "description": "second-filing-change-details-of-a-person-with-significant-control-limited-liability-partnership",
     "description_values": {
-      "psc_name": "Testing test Gp Limited"
+      "psc_name": "Testing Test Gp Limited"
     },
     "links": {
       "self": "/company/OC397230/filing-history/MzI1NTM3MDg2MXNhbHQ"

--- a/src/test/resources/data/officers/RP04PSC07_request_body.json
+++ b/src/test/resources/data/officers/RP04PSC07_request_body.json
@@ -7,7 +7,7 @@
     "date": "2017-07-31T17:49:31Z",
     "description": "second-filing-cessation-of-a-person-with-significant-control",
     "description_values": {
-      "psc_name": "Tester testman"
+      "psc_name": "Tester Testman"
     },
     "links": {
       "self": "/company/02569290/filing-history/MzE4MTg1Mjc5N3NhbHQ"


### PR DESCRIPTION
## Describe the changes
This PR changes the delete process to use the raw entity_id of a delta rather than the encoded entity_id. This change is due to a decision made for the logic in the API where we delete by entity_id rather than transaction_id.

Update dependencies in Pom.

Fix incorrect expected test data.

### Related Jira tickets
[DSND-2600](https://companieshouse.atlassian.net/browse/DSND-2600)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2600]: https://companieshouse.atlassian.net/browse/DSND-2600?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ