### PR TITLE
DSND-2612: Fix paper filed discrepancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,15 +62,18 @@ immediately to the <br>`filing-history-delta-filing-history-delta-consumer-inval
 | PORT                          | The port at which the service is hosted in ECS                                                  | 8080                                  |
 
 ## Building the docker image
-
-    mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
+```bash
+mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
+```
 
 ## To make local changes
 
 Development mode is available for this service
 in [Docker CHS Development](https://github.com/companieshouse/docker-chs-development).
 
-    ./bin/chs-dev development enable filing-history-delta-consumer
+```bash
+./bin/chs-dev development enable filing-history-delta-consumer
+```
 
 This will clone the `filing-history-delta-consumer` into the repositories folder. Any changes to the code, or resources
 will automatically trigger a rebuild and relaunch.

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/ExternalDataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/ExternalDataMapper.java
@@ -41,7 +41,7 @@ public class ExternalDataMapper {
         this.associatedFilingDeserialiser = associatedFilingDeserialiser;
     }
 
-    ExternalData mapExternalData(JsonNode topLevelNode, String barcode, String documentId, String encodedId,
+    ExternalData mapExternalData(JsonNode topLevelNode, String barcode, String encodedId,
                                  String companyNumber) {
         JsonNode dataNode = getNestedJsonNodeFromJsonNode(topLevelNode, "data");
 
@@ -71,7 +71,7 @@ public class ExternalDataMapper {
                 .barcode(barcode)
                 .descriptionValues(
                         descriptionValuesMapper.map(getNestedJsonNodeFromJsonNode(dataNode, "description_values")))
-                .paperFiled(paperFiledMapper.isPaperFiled(barcode, documentId) ? true : null)
+                .paperFiled(paperFiledMapper.isPaperFiled(barcode) ? true : null)
                 .links(linksMapper.map(companyNumber, encodedId))
                 .annotations(annotations)
                 .resolutions(resolutions)

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/InternalFilingHistoryApiMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/InternalFilingHistoryApiMapper.java
@@ -25,7 +25,7 @@ public class InternalFilingHistoryApiMapper {
     private final ExternalDataMapper externalDataMapper;
 
     public InternalFilingHistoryApiMapper(OriginalValuesMapper originalValuesMapper,
-            ExternalDataMapper externalDataMapper) {
+                                          ExternalDataMapper externalDataMapper) {
         this.originalValuesMapper = originalValuesMapper;
         this.externalDataMapper = externalDataMapper;
     }
@@ -56,7 +56,7 @@ public class InternalFilingHistoryApiMapper {
                 .updatedBy(args.updatedBy())
                 .transactionKind(kindResult.kind());
 
-        ExternalData externalData = externalDataMapper.mapExternalData(topLevelNode, barcode, documentId,
+        ExternalData externalData = externalDataMapper.mapExternalData(topLevelNode, barcode,
                 kindResult.encodedId(), args.companyNumber());
 
         return new InternalFilingHistoryApi()

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/PaperFiledMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/PaperFiledMapper.java
@@ -8,15 +8,8 @@ import org.springframework.stereotype.Component;
 public class PaperFiledMapper {
 
     private static final Pattern BARCODE_REGEX = Pattern.compile("^X");
-    private static final Pattern DOCUMENT_ID_REGEX = Pattern.compile("^...X", Pattern.CASE_INSENSITIVE);
 
-    public boolean isPaperFiled(final String barcode, final String documentId) {
-        if (StringUtils.isNotBlank(barcode)) {
-            return !BARCODE_REGEX.matcher(barcode).find();
-        }
-        if (StringUtils.isNotBlank(documentId)) {
-            return !DOCUMENT_ID_REGEX.matcher(documentId).find();
-        }
-        return true;
+    public boolean isPaperFiled(final String barcode) {
+        return StringUtils.isBlank(barcode) || !BARCODE_REGEX.matcher(barcode).find();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/ExternalDataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/ExternalDataMapperTest.java
@@ -30,7 +30,6 @@ class ExternalDataMapperTest {
     private static final String ENCODED_ID = "MzA1Njc0Mjg0N3NqYXNqamQ";
     private static final String BARCODE = "XAITVXAX";
     private static final String DESCRIPTION = "termination-director-company-with-name-termination-date";
-    private static final String DOCUMENT_ID = "000%s4682".formatted(BARCODE);
     private static final String COMPANY_NUMBER = "12345678";
     private static final String DATE = "20110905053919";
     private static final String TYPE = "TM01";
@@ -70,7 +69,7 @@ class ExternalDataMapperTest {
         when(categoryMapper.map(any())).thenReturn(CategoryEnum.OFFICERS);
         when(subcategoryMapper.map(any())).thenReturn(subcategory);
         when(descriptionValuesMapper.map(any())).thenReturn(descriptionValues);
-        when(paperFiledMapper.isPaperFiled(any(), any())).thenReturn(true);
+        when(paperFiledMapper.isPaperFiled(any())).thenReturn(true);
         when(linksMapper.map(any(), any())).thenReturn(links);
         when(annotationsDeserialiser.deserialise(any())).thenReturn(List.of(annotation));
 
@@ -81,7 +80,7 @@ class ExternalDataMapperTest {
         ExternalData expected = buildExpectedData();
 
         // when
-        ExternalData actual = externalDataMapper.mapExternalData(topLevelNode, BARCODE, DOCUMENT_ID, ENCODED_ID,
+        ExternalData actual = externalDataMapper.mapExternalData(topLevelNode, BARCODE, ENCODED_ID,
                 COMPANY_NUMBER);
 
         // then
@@ -89,7 +88,7 @@ class ExternalDataMapperTest {
         verify(subcategoryMapper).map(dataNode);
         verify(categoryMapper).map(dataNode);
         verify(descriptionValuesMapper).map(descriptionValuesNode);
-        verify(paperFiledMapper).isPaperFiled(BARCODE, DOCUMENT_ID);
+        verify(paperFiledMapper).isPaperFiled(BARCODE);
         verify(linksMapper).map(COMPANY_NUMBER, ENCODED_ID);
         verify(annotationsDeserialiser).deserialise(annotations);
     }
@@ -98,17 +97,17 @@ class ExternalDataMapperTest {
     void shouldMapExternalDataWithNullFields() {
         // given
         ExternalData expected = new ExternalData();
-        when(paperFiledMapper.isPaperFiled(any(), any())).thenReturn(false);
+        when(paperFiledMapper.isPaperFiled(any())).thenReturn(false);
 
         // when
-        ExternalData actual = externalDataMapper.mapExternalData(null, null, null, null, null);
+        ExternalData actual = externalDataMapper.mapExternalData(null, null, null, null);
 
         // then
         assertEquals(expected, actual);
         verify(subcategoryMapper).map(null);
         verify(categoryMapper).map(null);
         verify(descriptionValuesMapper).map(null);
-        verify(paperFiledMapper).isPaperFiled(null, null);
+        verify(paperFiledMapper).isPaperFiled(null);
         verify(linksMapper).map(null, null);
         verifyNoInteractions(annotationsDeserialiser);
     }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/InternalFilingHistoryApiMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/InternalFilingHistoryApiMapperTest.java
@@ -56,7 +56,7 @@ class InternalFilingHistoryApiMapperTest {
     void shouldMapJsonNodeToRequestBody() {
         // given
         when(originalValuesMapper.map(any())).thenReturn(internalDataOriginalValues);
-        when(externalDataMapper.mapExternalData(any(), any(), any(), any(), any())).thenReturn(externalData);
+        when(externalDataMapper.mapExternalData(any(), any(), any(), any())).thenReturn(externalData);
 
         JsonNode topLevelNode = buildJsonNode();
         JsonNode originalValuesNode = topLevelNode.get("original_values");
@@ -75,7 +75,7 @@ class InternalFilingHistoryApiMapperTest {
         // then
         assertEquals(expected, actualRequestBody);
         verify(originalValuesMapper).map(originalValuesNode);
-        verify(externalDataMapper).mapExternalData(topLevelNode, BARCODE, DOCUMENT_ID, ENCODED_ID, COMPANY_NUMBER);
+        verify(externalDataMapper).mapExternalData(topLevelNode, BARCODE, ENCODED_ID, COMPANY_NUMBER);
     }
 
     @Test
@@ -107,7 +107,7 @@ class InternalFilingHistoryApiMapperTest {
         // then
         assertEquals(expected, actualRequestBody);
         verify(originalValuesMapper).map(null);
-        verify(externalDataMapper).mapExternalData(null, null, null, ENCODED_ID, null);
+        verify(externalDataMapper).mapExternalData(null, null, ENCODED_ID, null);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/PaperFieldMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/PaperFieldMapperTest.java
@@ -11,27 +11,17 @@ class PaperFieldMapperTest {
 
     @ParameterizedTest
     @CsvSource(value = {
-            "XAITVXAX , 000XAITVXAX4682 , false",
-            "TAITVXAX , 000XAITVXAX4682 , true",
-            "XAITVXAX , 000TAITVXAX4682 , false",
-            "TAITVXAX , 000TAITVXAX4682 , true",
-            "null , 000XAITVXAX4682 , false",
-            "null , 000TAITVXAX4682 , true",
-            "XAITVXAX , null , false",
-            "TAITVXAX , null , true",
-            "null , null , true",
-            "'' , 000XAITVXAX4682 , false",
-            "'' , 000TAITVXAX4682 , true",
-            "XAITVXAX , '' , false",
-            "TAITVXAX , '' , true",
-            "'' , '' , true",
+            "XAITVXAX , false",
+            "TAITVXAX , true",
+            "null , true",
+            "'' , true"
     },
             nullValues = {"null"})
-    void testPaperFieldReturnsBooleanCorrectly(final String barcode, final String documentId, final boolean expected) {
+    void testPaperFieldReturnsBooleanCorrectly(final String barcode, final boolean expected) {
         // given
 
         // when
-        final boolean actual = mapper.isPaperFiled(barcode, documentId);
+        final boolean actual = mapper.isPaperFiled(barcode);
 
         // then
         assertEquals(expected, actual);


### PR DESCRIPTION
## Describe the changes
This PR removes the check against the 4th char in the document
  id. Previously, if the document id had an X in the 4th char, it
  would be considered electronic and so paper filed would be false
  and therefore not persisted. However, the Perl doesn't do this.
  instead, if the barcode is empty/null but the delta still has
  a document_id field that looks like this: "000X....", then
  paper_filed is still set to true in the Perl. This commit makes the Java do
  the same.

### Related Jira tickets
[DSND-2612](https://companieshouse.atlassian.net/browse/DSND-2612)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._
