### PR TITLE
DSND-2613: Fix bug where empty objects were being sent in request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapper.java
@@ -18,17 +18,21 @@ public class DescriptionValuesMapper {
 
     private final ArrayNodeDeserialiser<AltCapitalDescriptionValue> altCapitalArrayNodeDeserialiser;
     private final ArrayNodeDeserialiser<CapitalDescriptionValue> capitalArrayNodeDeserialiser;
+    private final JsonNodeCleaner jsonNodeCleaner;
 
     public DescriptionValuesMapper(ArrayNodeDeserialiser<AltCapitalDescriptionValue> altCapitalArrayNodeDeserialiser,
-                                   ArrayNodeDeserialiser<CapitalDescriptionValue> capitalArrayNodeDeserialiser) {
+                                   ArrayNodeDeserialiser<CapitalDescriptionValue> capitalArrayNodeDeserialiser, JsonNodeCleaner jsonNodeCleaner) {
         this.altCapitalArrayNodeDeserialiser = altCapitalArrayNodeDeserialiser;
         this.capitalArrayNodeDeserialiser = capitalArrayNodeDeserialiser;
+        this.jsonNodeCleaner = jsonNodeCleaner;
     }
 
-    public DescriptionValues map(final JsonNode jsonNode) {
-        if (jsonNode == null) {
+    public DescriptionValues map(final JsonNode inputNode) {
+        if (inputNode == null) {
             return null;
         }
+
+        JsonNode jsonNode = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
 
         List<AltCapitalDescriptionValue> altCapital = Optional.ofNullable(
                         getNestedJsonNodeFromJsonNode(jsonNode, "alt_capital"))

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapper.java
@@ -32,7 +32,7 @@ public class DescriptionValuesMapper {
             return null;
         }
 
-        JsonNode jsonNode = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
+        JsonNode jsonNode = jsonNodeCleaner.setEmptyStringsToNull(inputNode);
 
         List<AltCapitalDescriptionValue> altCapital = Optional.ofNullable(
                         getNestedJsonNodeFromJsonNode(jsonNode, "alt_capital"))

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.filinghistory.consumer.mapper.posttransform;
 
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -17,10 +18,11 @@ public class JsonNodeCleaner {
 
     JsonNode setEmptyStringsToNull(JsonNode inputNode) {
         ObjectNode outputNode = (ObjectNode) inputNode;
-        Map<?, ?> map = objectMapper.convertValue(outputNode, Map.class);
+        Map<String, Object> map = objectMapper.convertValue(outputNode, new TypeReference<>() {
+        });
         map.forEach((key, value) -> {
             if ("".equals(value)) {
-                outputNode.putNull(key.toString());
+                outputNode.putNull(key);
             }
         });
         return outputNode;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
@@ -15,7 +15,7 @@ public class JsonNodeCleaner {
         this.objectMapper = objectMapper;
     }
 
-    JsonNode cleanOutEmptyStrings(JsonNode inputNode) {
+    JsonNode setEmptyStringsToNull(JsonNode inputNode) {
         ObjectNode outputNode = (ObjectNode) inputNode;
         Map<?, ?> map = objectMapper.convertValue(outputNode, Map.class);
         for (Map.Entry<?, ?> entry : map.entrySet()) {

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
@@ -20,7 +20,7 @@ public class JsonNodeCleaner {
         Map<?, ?> map = objectMapper.convertValue(outputNode, Map.class);
         map.forEach((key, value) -> {
             if ("".equals(value)) {
-                outputNode.set(key.toString(), null);
+                outputNode.putNull(key.toString());
             }
         });
         return outputNode;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
@@ -1,0 +1,28 @@
+package uk.gov.companieshouse.filinghistory.consumer.mapper.posttransform;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonNodeCleaner {
+
+    private final ObjectMapper objectMapper;
+
+    public JsonNodeCleaner(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    JsonNode cleanOutEmptyStrings(JsonNode inputNode) {
+        ObjectNode outputNode = (ObjectNode) inputNode;
+        Map<?, ?> map = objectMapper.convertValue(outputNode, Map.class);
+        for (Map.Entry<?, ?> entry : map.entrySet()) {
+            if ("".equals(entry.getValue())) {
+                outputNode.set(entry.getKey().toString(), null);
+            }
+        }
+        return outputNode;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleaner.java
@@ -18,11 +18,11 @@ public class JsonNodeCleaner {
     JsonNode setEmptyStringsToNull(JsonNode inputNode) {
         ObjectNode outputNode = (ObjectNode) inputNode;
         Map<?, ?> map = objectMapper.convertValue(outputNode, Map.class);
-        for (Map.Entry<?, ?> entry : map.entrySet()) {
-            if ("".equals(entry.getValue())) {
-                outputNode.set(entry.getKey().toString(), null);
+        map.forEach((key, value) -> {
+            if ("".equals(value)) {
+                outputNode.set(key.toString(), null);
             }
-        }
+        });
         return outputNode;
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -119,7 +119,8 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
             "mortgage/MR04_rule_1", "mortgage/MR04_rule_2", "mortgage/MR04_rule_3", "mortgage/MR05_rule_1",
             "mortgage/MR05_rule_2", "mortgage/MR05_rule_3", "mortgage/MR05_rule_4", "mortgage/MR05_rule_5",
             "mortgage/MR05_rule_6", "mortgage/MR05_rule_7", "mortgage/MR06", "mortgage/MR07", "mortgage/MR08",
-            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)", "mortgage/LLP466(Scot)"
+            "mortgage/MR09", "mortgage/MR10", "mortgage/LLMR03", "mortgage/466(Scot)", "mortgage/LLP466(Scot)",
+            "mortgage/402R(NI)"
     })
     void shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromCSV(final String prefix) throws Exception {
         final String delta = IOUtils.resourceToString("/data/%s_delta.json".formatted(prefix), StandardCharsets.UTF_8);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapperTest.java
@@ -41,11 +41,13 @@ class DescriptionValuesMapperTest {
     private CapitalDescriptionValue capitalDescriptionValue;
     @Mock
     private AltCapitalDescriptionValue altCapitalDescriptionValue;
+    @Mock
+    private JsonNodeCleaner jsonNodeCleaner;
 
     @BeforeEach
     void setUp() {
         descriptionValuesMapper = new DescriptionValuesMapper(altCapitalArrayNodeDeserialiser,
-                capitalArrayNodeDeserialiser);
+                capitalArrayNodeDeserialiser, jsonNodeCleaner);
     }
 
     @Test
@@ -137,6 +139,7 @@ class DescriptionValuesMapperTest {
 
         when(altCapitalArrayNodeDeserialiser.deserialise(any())).thenReturn(List.of(altCapitalDescriptionValue));
         when(capitalArrayNodeDeserialiser.deserialise(any())).thenReturn(List.of(capitalDescriptionValue));
+        when(jsonNodeCleaner.cleanOutEmptyStrings(any())).thenReturn(jsonNode);
 
         // when
         final DescriptionValues actual = descriptionValuesMapper.map(jsonNode);
@@ -165,6 +168,25 @@ class DescriptionValuesMapperTest {
 
         // when
         final DescriptionValues actual = descriptionValuesMapper.map(null);
+
+        // then
+        assertNull(actual);
+    }
+
+    @Test
+    void shouldMapDescriptionValuesObjectToNullWhenOnlyEmptyFields() {
+        // given
+        final ObjectNode jsonNode = MAPPER.createObjectNode()
+                .putObject("description_values")
+                .put("description", "");
+
+        final ObjectNode outputNode = MAPPER.createObjectNode()
+                .putNull("description");
+
+        when(jsonNodeCleaner.cleanOutEmptyStrings(any())).thenReturn(outputNode);
+
+        // when
+        final DescriptionValues actual = descriptionValuesMapper.map(jsonNode);
 
         // then
         assertNull(actual);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/DescriptionValuesMapperTest.java
@@ -139,7 +139,7 @@ class DescriptionValuesMapperTest {
 
         when(altCapitalArrayNodeDeserialiser.deserialise(any())).thenReturn(List.of(altCapitalDescriptionValue));
         when(capitalArrayNodeDeserialiser.deserialise(any())).thenReturn(List.of(capitalDescriptionValue));
-        when(jsonNodeCleaner.cleanOutEmptyStrings(any())).thenReturn(jsonNode);
+        when(jsonNodeCleaner.setEmptyStringsToNull(any())).thenReturn(jsonNode);
 
         // when
         final DescriptionValues actual = descriptionValuesMapper.map(jsonNode);
@@ -183,7 +183,7 @@ class DescriptionValuesMapperTest {
         final ObjectNode outputNode = MAPPER.createObjectNode()
                 .putNull("description");
 
-        when(jsonNodeCleaner.cleanOutEmptyStrings(any())).thenReturn(outputNode);
+        when(jsonNodeCleaner.setEmptyStringsToNull(any())).thenReturn(outputNode);
 
         // when
         final DescriptionValues actual = descriptionValuesMapper.map(jsonNode);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleanerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleanerTest.java
@@ -1,0 +1,51 @@
+package uk.gov.companieshouse.filinghistory.consumer.mapper.posttransform;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.filinghistory.consumer.transformrules.TransformerTestingUtils;
+
+class JsonNodeCleanerTest {
+
+    private static final ObjectMapper MAPPER = TransformerTestingUtils.getMapper();
+
+    private JsonNodeCleaner jsonNodeCleaner;
+
+    @BeforeEach
+    void setUp() {
+        jsonNodeCleaner = new JsonNodeCleaner(MAPPER);
+    }
+
+    @Test
+    void shouldChangeEmptyStringValuesToNull() {
+        // given
+        JsonNode inputNode = MAPPER.createObjectNode()
+                .put("description", "");
+
+        JsonNode expected = MAPPER.createObjectNode()
+                .putNull("description");
+
+        // when
+        JsonNode actual = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldRemainUnchangedIfNoEmptyString() {
+        // given
+        JsonNode inputNode = MAPPER.createObjectNode()
+                .put("description", "description");
+
+        // when
+        JsonNode actual = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
+
+        // then
+        assertEquals(inputNode, actual);
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleanerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/mapper/posttransform/JsonNodeCleanerTest.java
@@ -29,7 +29,7 @@ class JsonNodeCleanerTest {
                 .putNull("description");
 
         // when
-        JsonNode actual = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
+        JsonNode actual = jsonNodeCleaner.setEmptyStringsToNull(inputNode);
 
         // then
         assertEquals(expected, actual);
@@ -42,7 +42,7 @@ class JsonNodeCleanerTest {
                 .put("description", "description");
 
         // when
-        JsonNode actual = jsonNodeCleaner.cleanOutEmptyStrings(inputNode);
+        JsonNode actual = jsonNodeCleaner.setEmptyStringsToNull(inputNode);
 
         // then
         assertEquals(inputNode, actual);

--- a/src/test/resources/data/mortgage/402R(NI)_delta.json
+++ b/src/test/resources/data/mortgage/402R(NI)_delta.json
@@ -1,0 +1,18 @@
+{
+  "filing_history": [
+    {
+      "category": "4",
+      "receive_date": "20080422000000",
+      "form_type": "402R(NI)",
+      "description": "",
+      "barcode": "00492386",
+      "document_id": "NIA097063800000",
+      "company_number": "NI060142",
+      "entity_id": "2502192664",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20240315120619637819"
+}

--- a/src/test/resources/data/mortgage/402R(NI)_request_body.json
+++ b/src/test/resources/data/mortgage/402R(NI)_request_body.json
@@ -1,0 +1,23 @@
+{
+  "external_data" : {
+    "transaction_id" : "MjUwMjE5MjY2NHNhbHQ",
+    "barcode" : "00492386",
+    "type" : "402R(NI)",
+    "date" : "2008-04-22T00:00:00Z",
+    "category" : "mortgage",
+    "description" : "particulars-of-a-mortgage-charge",
+    "paper_filed" : true,
+    "links" : {
+      "self" : "/company/NI060142/filing-history/MjUwMjE5MjY2NHNhbHQ"
+    }
+  },
+  "internal_data": {
+    "delta_at" : "20240315120619637819",
+    "updated_by": "context_id",
+    "transaction_kind": "top-level",
+    "entity_id" : "2502192664",
+    "company_number" : "NI060142",
+    "document_id" : "NIA097063800000",
+    "parent_entity_id": ""
+  }
+}


### PR DESCRIPTION
* Previously, description_values would be sent in the request body as an object with all it's fields being null or empty strings.
* This fix now makes it so any description_values objects that have no populated fields (i.e., not null or empty), will be set to null in the mapping process, and so not sent in the request body to the API.

## Describe the changes

### Related Jira tickets
[DSND-2613](https://companieshouse.atlassian.net/browse/DSND-2613)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2613]: https://companieshouse.atlassian.net/browse/DSND-2613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ