### PR TITLE
DSND-2657: Do not transform original_values

### DIFF
--- a/src/main/resources/transform_rules.yml
+++ b/src/main/resources/transform_rules.yml
@@ -3548,7 +3548,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR01
@@ -3564,7 +3563,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR01
@@ -3580,7 +3578,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR01
@@ -3617,7 +3614,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: MR02
@@ -3633,7 +3629,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: MR02
@@ -3649,7 +3644,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: MR02
@@ -3686,7 +3680,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR03
@@ -3702,7 +3695,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR03
@@ -3718,7 +3710,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR03
@@ -3914,7 +3905,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR08
@@ -3930,7 +3920,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR08
@@ -3946,7 +3935,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR08
@@ -4025,7 +4013,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR10
@@ -4041,7 +4028,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR10
@@ -4057,7 +4043,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: MR10
@@ -4082,7 +4067,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR01
@@ -4098,7 +4082,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR01
@@ -4114,7 +4097,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR01
@@ -4178,7 +4160,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR02
@@ -4194,7 +4175,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR02
@@ -4210,7 +4190,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% propertyAcquiredDate | bson_date %]'
       data.description_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
-      original_values.property_acquired_date: '[% propertyAcquiredDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR02
@@ -4247,7 +4226,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR03
@@ -4263,7 +4241,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR03
@@ -4279,7 +4256,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR03
@@ -4475,7 +4451,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR08
@@ -4491,7 +4466,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR08
@@ -4507,7 +4481,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR08
@@ -4598,7 +4571,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR10
@@ -4614,7 +4586,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR10
@@ -4630,7 +4601,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLMR10
@@ -4750,7 +4720,6 @@
       original_description: '[% data.description | sentence_case %]'
       data.action_date: '[% chargeCreationDate | bson_date %]'
       data.description_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
-      original_values.charge_creation_date: '[% chargeCreationDate | bson_date %]'
 - when:
     eq:
       data.type: LLP466(Scot)

--- a/src/test/resources/data/mortgage/LLP466(Scot)_request_body.json
+++ b/src/test/resources/data/mortgage/LLP466(Scot)_request_body.json
@@ -23,7 +23,7 @@
     "entity_id": "2042077166",
     "original_description": "Particulars of an instrument of alteration of a floating charge / charge no: 2",
     "original_values": {
-      "charge_creation_date": "2009-09-01T00:00:00Z"
+      "charge_creation_date": "01/09/2009"
     },
     "parent_entity_id": "",
     "delta_at": "20211029142043360560",

--- a/src/test/resources/data/mortgage/MR02_rule_3_request_body.json
+++ b/src/test/resources/data/mortgage/MR02_rule_3_request_body.json
@@ -20,7 +20,7 @@
   "internal_data": {
     "original_description": "Acquisition of a charge / charge code 123456780657",
     "original_values": {
-      "property_acquired_date": "2014-08-21T00:00:00Z"
+      "property_acquired_date": "21/08/2014"
     },
     "company_number": "12345678",
     "document_id": "000A3FTQQVF5668",


### PR DESCRIPTION
## Describe the changes
* Stops transformation of charge_creation_date and property_acquired_date original values.

### Related Jira tickets
[DSND-2657](https://companieshouse.atlassian.net/browse/DSND-2657)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2657]: https://companieshouse.atlassian.net/browse/DSND-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ