### PR TITLE
DSND-2692: Harvest Perl GET responses

### DIFF
--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkIntegrationTestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkIntegrationTestUtils.java
@@ -35,7 +35,7 @@ public class BulkIntegrationTestUtils {
     private static final String QUEUE_API_URL = "http://localhost:18201/queue/delta/filing-history";
     private static final String DELTA_API_URL = "http://api.chs.local:4001/delta/filing-history";
     private static final String BACKEND_API_URL = "http://api.chs.local:4001";
-    private static final String FILING_HISTORY_API_URL = "http://api.chs.local:4001/filing-history-data-api";
+    private static final String FILING_HISTORY_API_URL = "http://api.chs.local:4001";
 
     private static final String FIND_ALL_DELTAS = """
             SELECT
@@ -45,8 +45,22 @@ public class BulkIntegrationTestUtils {
             FROM
                 capdevjco2.fh_staging_deltas
             WHERE
-                    entity_id NOT IN (3168588719, 3183361204, -- Broken in Java or Perl consumers
-                                      3183361204, 2030121631, 2041074305) -- Broken in Java consumer
+                    entity_id NOT IN (3168588719, 3183361204) -- Broken in Java and Perl consumers
+            """;
+
+    private static final String FIND_ALL_PERL_DOCS = """
+            SELECT
+                entity_id,
+                transaction_id,
+                form_type,
+                company_number,
+                perl_delta,
+                java_delta,
+                perl_document,
+                perl_get_single_response,
+                perl_get_list_response
+            FROM
+                capdevjco2.bulk_testing_perl_docs
             """;
 
     private BulkIntegrationTestUtils() {
@@ -84,6 +98,20 @@ public class BulkIntegrationTestUtils {
                         rs.getString("entity_id"),
                         rs.getString("api_delta"),
                         rs.getString("queue_delta")));
+    }
+
+    static @Nonnull List<PerlDocuments> findAllPerlDocs() throws SQLException {
+        return new JdbcTemplate(chipsSource()).query(BulkIntegrationTestUtils.FIND_ALL_PERL_DOCS,
+                (rs, rowNum) -> new PerlDocuments(
+                        rs.getString("entity_id"),
+                        rs.getString("transaction_id"),
+                        rs.getString("form_type"),
+                        rs.getString("company_number"),
+                        rs.getString("perl_delta"),
+                        rs.getString("java_delta"),
+                        rs.getString("perl_document"),
+                        rs.getString("perl_get_single_response"),
+                        rs.getString("perl_get_list_response")));
     }
 
     static DataSource chipsSource() throws SQLException {

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/E2EGetResponseIntegrationIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/E2EGetResponseIntegrationIT.java
@@ -136,7 +136,7 @@ class E2EGetResponseIntegrationIT {
                         })
                         .body(String.class);
             } catch (Exception e) {
-                logger.info("Retrying to GET single transaction list for company {}, transaction {}", companyNumber,
+                logger.info("Retrying to GET single transaction for company {}, transaction {}", companyNumber,
                         transactionId, e);
             }
         }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/E2EGetResponseIntegrationIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/E2EGetResponseIntegrationIT.java
@@ -2,11 +2,11 @@ package uk.gov.companieshouse.filinghistory.consumer.kafka;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findFilingHistoryDocument;
 import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getDeltaApiRestClient;
 import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getFilingHistoryApiRestClient;
 import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getFilingHistoryCollection;
 import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.postDelta;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.sleep;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,6 +17,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
+import jakarta.annotation.Nullable;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -24,6 +25,7 @@ import java.util.Optional;
 import java.util.UUID;
 import org.apache.http.HttpStatus;
 import org.bson.Document;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ArgumentsSource;
@@ -43,6 +45,11 @@ class E2EGetResponseIntegrationIT {
 
     private final MongoClient mongoClient = BulkIntegrationTestUtils.mongoClient();
     private final MongoCollection<Document> filingHistoryCollection = getFilingHistoryCollection(mongoClient);
+
+    @BeforeEach
+    void setUp() {
+        filingHistoryCollection.deleteMany(new Document());
+    }
 
     @ParameterizedTest(name = "[{index}] {1}/{2}/{0}")
     @ArgumentsSource(IntegrationGETResponseGenerator.class)
@@ -66,22 +73,8 @@ class E2EGetResponseIntegrationIT {
             document = findFilingHistoryDocument(filingHistoryCollection, formType, entityId, 10_000);
             assertNotNull(document);
 
-            String singleDocumentJson = apiClient.get()
-                    .uri("/company/{companyNumber}/filing-history/{transactionId}", companyNumber, transactionId)
-                    .header("x-request-id", UUID.randomUUID().toString())
-                    .retrieve()
-                    .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
-                        throw new RuntimeException(response.getStatusText());
-                    })
-                    .body(String.class);
-            String documentListJson = apiClient.get()
-                    .uri("/company/{companyNumber}/filing-history", companyNumber)
-                    .header("x-request-id", UUID.randomUUID().toString())
-                    .retrieve()
-                    .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
-                        throw new RuntimeException(response.getStatusText());
-                    })
-                    .body(String.class);
+            String singleDocumentJson = fetchSingleTransaction(transactionId, companyNumber, 1_000);
+            String documentListJson = fetchTransactionList(companyNumber, 1_000);
 
             JsonNode javaSingleDocument = parseAndRemoveNulls(singleDocumentJson);
             JsonNode javaDocumentList = parseAndRemoveNulls(documentListJson);
@@ -105,6 +98,67 @@ class E2EGetResponseIntegrationIT {
                 filingHistoryCollection.deleteOne(document);
             }
         }
+    }
+
+    private @Nullable String fetchTransactionList(String companyNumber, long waitMillis) {
+
+        for (int count = 0; count < waitMillis; count++) {
+            sleep(1);
+
+            try {
+                return apiClient.get()
+                        .uri("/company/{companyNumber}/filing-history", companyNumber)
+                        .header("x-request-id", UUID.randomUUID().toString())
+                        .retrieve()
+                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
+                            throw new RuntimeException(response.getStatusText());
+                        })
+                        .body(String.class);
+            } catch (Exception e) {
+                logger.info("Retrying to GET transaction list for {}", companyNumber);
+            }
+        }
+
+        throw new RuntimeException("Retrying to GET transaction list for %s".formatted(companyNumber));
+    }
+
+    private @Nullable String fetchSingleTransaction(String transactionId, String companyNumber, long waitMillis) {
+        for (int count = 0; count < waitMillis; count++) {
+            sleep(1);
+
+            try {
+                return apiClient.get()
+                        .uri("/company/{companyNumber}/filing-history/{transactionId}", companyNumber, transactionId)
+                        .header("x-request-id", UUID.randomUUID().toString())
+                        .retrieve()
+                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
+                            throw new RuntimeException(response.getStatusText());
+                        })
+                        .body(String.class);
+            } catch (Exception e) {
+                logger.info("Retrying to GET single transaction list for company {}, transaction {}", companyNumber,
+                        transactionId, e);
+            }
+        }
+
+        throw new RuntimeException("Retrying to GET transaction for company %s, transaction %s"
+                .formatted(companyNumber, transactionId));
+    }
+
+    private Document findFilingHistoryDocument(MongoCollection<Document> collection, String formType, String entityId,
+            long waitMillis) {
+        for (int count = 0; count < waitMillis; count++) {
+            sleep(1);
+
+            Document document = collection.find().first();
+            if (document != null) {
+                logger.info("Document {} found after {} milliseconds", document.get("_id"), count);
+                return document;
+            }
+        }
+
+        throw new RuntimeException("Failed to read filing history document for form %s, entityId %s"
+                .formatted(formType, entityId));
     }
 
     private void maskSingleDocumentKnownBugs(JsonNode perlSingleDocument, JsonNode javaSingleDocument) {

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/IntegrationGETResponseGenerator.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/IntegrationGETResponseGenerator.java
@@ -1,32 +1,16 @@
 package uk.gov.companieshouse.filinghistory.consumer.kafka;
 
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findAllDeltas;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findFilingHistoryDocument;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getBackendRestClient;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getFilingHistoryCollection;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getQueueApiRestClient;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.mongoClient;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.postDelta;
-import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.sleep;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findAllPerlDocs;
 
-import com.jayway.jsonpath.DocumentContext;
-import com.jayway.jsonpath.JsonPath;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.model.Filters;
 import java.sql.SQLException;
 import java.util.Queue;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.stream.Stream;
-import org.apache.http.HttpStatus;
-import org.bson.Document;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.ArgumentsProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.client.RestClient;
 
 public class IntegrationGETResponseGenerator implements ArgumentsProvider {
 
@@ -35,45 +19,14 @@ public class IntegrationGETResponseGenerator implements ArgumentsProvider {
     @Override
     public Stream<? extends Arguments> provideArguments(ExtensionContext context) {
 
-        try (MongoClient mongoClient = mongoClient()) {
-            MongoCollection<Document> filingHistoryCollection = getFilingHistoryCollection(mongoClient);
-            RestClient queueApiClient = getQueueApiRestClient();
-            RestClient backendClient = getBackendRestClient();
-
-            filingHistoryCollection.deleteMany(new Document());
-
+        try {
             Queue<Arguments> queue = new ConcurrentLinkedQueue<>();
-            findAllDeltas().forEach(deltas -> {
-
-                try {
-                    if (deltas.javaDelta() != null && deltas.perlDelta() != null) {
-
-                        DocumentContext delta = JsonPath.parse(deltas.javaDelta());
-                        String entityId = delta.read("$.filing_history[0].entity_id");
-                        String formType = delta.read("$.filing_history[0].form_type");
-                        String companyNumber = delta.read("$.filing_history[0].company_number");
-
-                        postDelta(deltas.perlDelta(), queueApiClient);
-                        Document perlDocument = findFilingHistoryDocument(filingHistoryCollection, formType, entityId,
-                                20_000);
-
-                        String transactionId = perlDocument.getString("_id");
-                        String perlGetSingleResponse = fetchGetSingleDocument(companyNumber, transactionId,
-                                backendClient);
-                        String perlGetListResponse = fetchGetDocumentList(companyNumber, backendClient);
-
-                        filingHistoryCollection.deleteMany(
-                                Filters.and(Filters.eq("_id", perlDocument.get("_id"))));
-
-                        queue.add(Arguments.of(transactionId, formType, entityId, companyNumber, deltas.javaDelta(),
-                                perlGetSingleResponse, perlGetListResponse));
-
-                    } else {
-                        logger.warn("No delta JSON found for transaction {}", deltas.entity_id());
-                    }
-                } catch (Exception e) {
-                    logger.error("Processing failed Perl delta: transaction_id %s, Perl %s".formatted(
-                            deltas.entity_id(), deltas.perlDelta()), e);
+            findAllPerlDocs().forEach(docs -> {
+                if (docs.javaDelta() != null && docs.perlDelta() != null) {
+                    queue.add(Arguments.of(docs.transactionId(), docs.formType(), docs.entityId(), docs.companyNumber(),
+                            docs.javaDelta(), docs.perlGetSingleResponse(), docs.perlGetListResponse()));
+                } else {
+                    logger.warn("No delta JSON found for transaction {}", docs.entityId());
                 }
             });
             logger.info("Done");
@@ -82,49 +35,5 @@ public class IntegrationGETResponseGenerator implements ArgumentsProvider {
             logger.error("Failed accessing the CHIPS database", e);
             throw new RuntimeException(e);
         }
-    }
-
-    private String fetchGetSingleDocument(String companyNumber, String transactionId, RestClient backendClient) {
-
-        for (int count = 0; count < 2000; count++) {
-            try {
-                sleep(1);
-
-                return backendClient.get()
-                        .uri("/company/{companyNumber}/filing-history/{transactionId}", companyNumber, transactionId)
-                        .header("x-request-id", UUID.randomUUID().toString())
-                        .retrieve()
-                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
-                            throw new RuntimeException(response.getStatusText());
-                        })
-                        .body(String.class);
-            } catch (Exception e) {
-                logger.info("Retrying GET single filing history document for transaction %s"
-                        .formatted(transactionId));
-            }
-        }
-        throw new RuntimeException("Failed to GET single filing history document for transaction %s"
-                .formatted(transactionId));
-    }
-
-    private String fetchGetDocumentList(String companyNumber, RestClient backendClient) {
-
-        for (int count = 0; count < 2000; count++) {
-            try {
-                sleep(1);
-
-                return backendClient.get()
-                        .uri("/company/{companyNumber}/filing-history", companyNumber)
-                        .header("x-request-id", UUID.randomUUID().toString())
-                        .retrieve()
-                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
-                            throw new RuntimeException(response.getStatusText());
-                        })
-                        .body(String.class);
-            } catch (Exception e) {
-                logger.info("Retrying GET filing history list for company %s".formatted(companyNumber));
-            }
-        }
-        throw new RuntimeException("Failed to GET filing history list for company %s".formatted(companyNumber));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PerlDocumentExtractor.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PerlDocumentExtractor.java
@@ -1,0 +1,158 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findAllDeltas;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.findFilingHistoryDocument;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getBackendRestClient;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getFilingHistoryCollection;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.getQueueApiRestClient;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.mongoClient;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.postDelta;
+import static uk.gov.companieshouse.filinghistory.consumer.kafka.BulkIntegrationTestUtils.sleep;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.Filters;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.sql.SQLException;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.commons.io.FileUtils;
+import org.apache.http.HttpStatus;
+import org.bson.Document;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestClient;
+
+public class PerlDocumentExtractor {
+
+    private static final Logger logger = LoggerFactory.getLogger(PerlDocumentExtractor.class);
+    private static final String BULK_TESTING_PERL_DOCS_CSV = "bulk-testing-perl-docs.csv";
+    private static final String HEADER_ROW_FMT = "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s";
+    private static final String ROW_FMT =
+            "%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s"
+                    + "\t%s";
+
+    public static void main(String[] args) throws IOException {
+
+        FileUtils.touch(new File(BULK_TESTING_PERL_DOCS_CSV));
+
+        try (MongoClient mongoClient = mongoClient();
+                PrintWriter out = new PrintWriter(BULK_TESTING_PERL_DOCS_CSV)) {
+
+            out.println(HEADER_ROW_FMT.formatted("entity_id", "transaction_id", "form_type", "company_number",
+                    "perl_delta", "java_delta", "perl_document", "perl_get_single_response", "perl_get_list_response"));
+
+            MongoCollection<Document> filingHistoryCollection = getFilingHistoryCollection(mongoClient);
+            RestClient queueApiClient = getQueueApiRestClient();
+            RestClient backendClient = getBackendRestClient();
+
+            filingHistoryCollection.deleteMany(new Document());
+
+            findAllDeltas().forEach(deltas -> {
+
+                try {
+                    if (deltas.javaDelta() != null && deltas.perlDelta() != null) {
+
+                        DocumentContext delta = JsonPath.parse(deltas.javaDelta());
+                        String entityId = delta.read("$.filing_history[0].entity_id");
+                        String formType = delta.read("$.filing_history[0].form_type");
+                        String companyNumber = delta.read("$.filing_history[0].company_number");
+
+                        postDelta(deltas.perlDelta(), queueApiClient);
+                        Document perlDocument = findFilingHistoryDocument(filingHistoryCollection, formType, entityId,
+                                20_000);
+
+                        String transactionId = perlDocument.getString("_id");
+                        String perlGetSingleResponse = fetchGetSingleDocument(companyNumber, transactionId,
+                                backendClient);
+                        String perlGetListResponse = fetchGetDocumentList(companyNumber, backendClient);
+
+                        filingHistoryCollection.deleteMany(
+                                Filters.and(Filters.eq("_id", perlDocument.get("_id"))));
+
+                        out.println(ROW_FMT.formatted(entityId, transactionId, formType,
+                                companyNumber, escapeSpecialCharacters(deltas.perlDelta()),
+                                escapeSpecialCharacters(deltas.javaDelta()),
+                                escapeSpecialCharacters(perlDocument.toJson()),
+                                escapeSpecialCharacters(perlGetSingleResponse),
+                                escapeSpecialCharacters(perlGetListResponse)));
+
+                    } else {
+                        logger.warn("No delta JSON found for transaction {}", deltas.entity_id());
+                    }
+                } catch (Exception e) {
+                    logger.error("Processing failed Perl delta: transaction_id %s, Perl %s".formatted(
+                            deltas.entity_id(), deltas.perlDelta()), e);
+                }
+            });
+            logger.info("Done");
+        } catch (SQLException e) {
+            logger.error("Failed accessing the CHIPS database", e);
+            throw new RuntimeException(e);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static String escapeSpecialCharacters(String data) {
+        Objects.requireNonNull(data, "Input data cannot be null");
+        return data.replaceAll("\\R", "");
+    }
+
+
+    private static String fetchGetSingleDocument(String companyNumber, String transactionId, RestClient backendClient) {
+
+        for (int count = 0; count < 2000; count++) {
+            try {
+                sleep(1);
+
+                return backendClient.get()
+                        .uri("/company/{companyNumber}/filing-history/{transactionId}", companyNumber, transactionId)
+                        .header("x-request-id", UUID.randomUUID().toString())
+                        .retrieve()
+                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
+                            throw new RuntimeException(response.getStatusText());
+                        })
+                        .body(String.class);
+            } catch (Exception e) {
+                logger.info("Retrying GET single filing history document for transaction %s"
+                        .formatted(transactionId));
+            }
+        }
+        throw new RuntimeException("Failed to GET single filing history document for transaction %s"
+                .formatted(transactionId));
+    }
+
+    private static String fetchGetDocumentList(String companyNumber, RestClient backendClient) {
+
+        for (int count = 0; count < 2000; count++) {
+            try {
+                sleep(1);
+
+                return backendClient.get()
+                        .uri("/company/{companyNumber}/filing-history", companyNumber)
+                        .header("x-request-id", UUID.randomUUID().toString())
+                        .retrieve()
+                        .onStatus(status -> status.value() != HttpStatus.SC_OK, (request, response) -> {
+                            throw new RuntimeException(response.getStatusText());
+                        })
+                        .body(String.class);
+            } catch (Exception e) {
+                logger.info("Retrying GET filing history list for company %s".formatted(companyNumber));
+            }
+        }
+        throw new RuntimeException("Failed to GET filing history list for company %s".formatted(companyNumber));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PerlDocuments.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/PerlDocuments.java
@@ -1,0 +1,14 @@
+package uk.gov.companieshouse.filinghistory.consumer.kafka;
+
+record PerlDocuments(
+        String entityId,
+        String transactionId,
+        String formType,
+        String companyNumber,
+        String perlDelta,
+        String javaDelta,
+        String perlDocument,
+        String perlGetSingleResponse,
+        String perlGetListResponse) {
+
+}


### PR DESCRIPTION
## Describe the changes
The Bulk E2E tests need the GET responses from the Perl endpoints to compare with the output of the Java ones.
* Capture Perl GET responses using deltas from Staging
* Import these to a Kermit table `capdevjco2.bulk_testing_perl_docs`
* Update bulk test queries to source test data from the new table
* Update the Java API URIs to remove the `filing-history-data-api` prefix
* Added a utility class to harvest the Perl GET responses if the data table needs refreshing

### Related Jira tickets
[DSND-2692](https://companieshouse.atlassian.net/browse/DSND-2692)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [x] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2692]: https://companieshouse.atlassian.net/browse/DSND-2692?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ