### PR TITLE
DSND-2689: Mask known description differences in E2EGetResponseIntegationIT

### DIFF
--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkIntegrationTestUtils.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/BulkIntegrationTestUtils.java
@@ -45,7 +45,7 @@ public class BulkIntegrationTestUtils {
             FROM
                 capdevjco2.fh_staging_deltas
             WHERE
-                    entity_id NOT IN (3168588719, 3183361204) -- Broken in Java and Perl consumers
+                entity_id NOT IN (3168588719, 3183361204) -- Broken in Java and Perl consumers
             """;
 
     private static final String FIND_ALL_PERL_DOCS = """


### PR DESCRIPTION
## Describe the changes
Updates to E2EGetResponseIntegrationIT include:
* Fixed some cases where the Java and Perl document ordering was mixed up
* Added a masking function to ignore description values where the rules have changed

### Related Jira tickets
[DSND-2689](https://companieshouse.atlassian.net/browse/DSND-2689)

## Developer check list
### General
- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-2689]: https://companieshouse.atlassian.net/browse/DSND-2689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ