### PR TITLE
DSND-3122: Bump private sdk version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.14</structured-logging.version>
     <sdk-manager-java.version>3.0.3</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.211</private-api-sdk-java.version>
+    <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
     <kafka-models.version>3.0.4</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.14</structured-logging.version>
     <sdk-manager-java.version>3.0.3</sdk-manager-java.version>
-    <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.217</private-api-sdk-java.version>
     <kafka-models.version>3.0.4</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/kafka/Consumer.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/kafka/Consumer.java
@@ -1,10 +1,7 @@
 package uk.gov.companieshouse.filinghistory.consumer.kafka;
 
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.kafka.retrytopic.RetryTopicHeaders;
-import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.filinghistory.consumer.exception.RetryableException;
@@ -27,11 +24,7 @@ public class Consumer {
             topics = {"${consumer.topic}"},
             groupId = "${consumer.group-id}"
     )
-    public void consume(Message<ChsDelta> message,
-            @Header(name = RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS, required = false) Integer attempt,
-            @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
-            @Header(KafkaHeaders.RECEIVED_PARTITION) Integer partition,
-            @Header(KafkaHeaders.OFFSET) Long offset) {
+    public void consume(Message<ChsDelta> message) {
         try {
             router.route(message.getPayload());
         } catch (RetryableException ex) {

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/logging/LoggingKafkaListenerAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/logging/LoggingKafkaListenerAspectTest.java
@@ -1,0 +1,216 @@
+package uk.gov.companieshouse.filinghistory.consumer.logging;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
+import static org.springframework.kafka.retrytopic.RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS;
+import static org.springframework.kafka.support.KafkaHeaders.OFFSET;
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_PARTITION;
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_TOPIC;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.regex.Pattern;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHeaders;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.filinghistory.consumer.exception.NonRetryableException;
+import uk.gov.companieshouse.filinghistory.consumer.exception.RetryableException;
+
+@ExtendWith(MockitoExtension.class)
+class LoggingKafkaListenerAspectTest {
+
+    private static final String CONTEXT_ID = "context_id";
+    private static final String TOPIC = "filing-history-delta";
+    private static final Pattern INFO_EVENT_PATTERN = Pattern.compile(
+            "event: info|\"event\":\"info\"");
+    private static final Pattern ERROR_EVENT_PATTERN = Pattern.compile(
+            "event: error|\"event\":\"error\"");
+    private static final Pattern MAX_RETRY_ATTEMPTS_REACHED_PATTERN = Pattern.compile(
+            "error: Max retry attempts reached|\"message\":\"Max retry attempts reached\"");
+    private static final Pattern INVALID_PAYLOAD_PATTERN = Pattern.compile(
+            "error: Invalid payload type, payload: \\[message payload]|\"message\":\"Invalid payload type, payload: \\[message payload]\"");
+    private static final Pattern REQUEST_ID_INITIALISED_PATTERN = Pattern.compile(
+            "request_id: context_id|\"request_id\":\"context_id\"");
+    private static final Pattern REQUEST_ID_UNINITIALISED_PATTERN = Pattern.compile(
+            "request_id: uninitialised|\"event\":\"error\"");
+    private static final Pattern RETRY_COUNT_ZERO_PATTERN = Pattern.compile(
+            "retry_count: 0|\"retry_count\":0");
+    private static final Pattern RETRY_COUNT_FOUR_PATTERN = Pattern.compile(
+            "retry_count: 4|\"retry_count\":4");
+    private static final Pattern MAIN_TOPIC_PATTERN = Pattern.compile(
+            "topic: filing-history-delta|\"topic\":\"filing-history-delta\"");
+    private static final Pattern PARTITION_ZERO_PATTERN = Pattern.compile(
+            "partition: 0|\"partition\":0");
+    private static final Pattern OFFSET_ZERO_PATTERN = Pattern.compile(
+            "offset: 0|\"offset\":0");
+
+    private LoggingKafkaListenerAspect aspect;
+
+    @Mock
+    private ProceedingJoinPoint joinPoint;
+    @Mock
+    private Message<ChsDelta> message;
+    @Mock
+    private ChsDelta delta;
+    @Mock
+    private Message<String> invalidMessage;
+
+    @BeforeEach
+    void setUp() {
+        aspect = new LoggingKafkaListenerAspect(5);
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldManageStructuredLogging(CapturedOutput capture) throws Throwable {
+        // given
+        MessageHeaders headers = new MessageHeaders(
+                Map.of(
+                        RECEIVED_TOPIC, TOPIC,
+                        RECEIVED_PARTITION, 0,
+                        OFFSET, 0L));
+        Object expected = "result";
+        when(joinPoint.getArgs()).thenReturn(new Object[]{message});
+        when(message.getPayload()).thenReturn(delta);
+        when(message.getHeaders()).thenReturn(headers);
+        when(delta.getContextId()).thenReturn(CONTEXT_ID);
+        when(joinPoint.proceed()).thenReturn(expected);
+
+        // when
+        Object actual = aspect.manageStructuredLogging(joinPoint);
+
+        //then
+        assertEquals(expected, actual);
+        assertTrue(capture.getOut().contains("Processed delta"));
+        verifyInfoLogMap(capture);
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldManageStructuredLoggingDeleteDelta(CapturedOutput capture) throws Throwable {
+        // given
+        MessageHeaders headers = new MessageHeaders(
+                Map.of(
+                        RECEIVED_TOPIC, TOPIC,
+                        RECEIVED_PARTITION, 0,
+                        OFFSET, 0L));
+        Object expected = "result";
+        when(joinPoint.getArgs()).thenReturn(new Object[]{message});
+        when(message.getPayload()).thenReturn(delta);
+        when(message.getHeaders()).thenReturn(headers);
+        when(delta.getContextId()).thenReturn(CONTEXT_ID);
+        when(delta.getIsDelete()).thenReturn(true);
+        when(joinPoint.proceed()).thenReturn(expected);
+
+        // when
+        Object actual = aspect.manageStructuredLogging(joinPoint);
+
+        //then
+        assertEquals(expected, actual);
+        assertTrue(capture.getOut().contains("Processed DELETE delta"));
+        verifyInfoLogMap(capture);
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldLogInfoWhenRetryableException(CapturedOutput capture) throws Throwable {
+        // given
+        MessageHeaders headers = new MessageHeaders(
+                Map.of(
+                        RECEIVED_TOPIC, TOPIC,
+                        RECEIVED_PARTITION, 0,
+                        OFFSET, 0L));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{message});
+        when(message.getPayload()).thenReturn(delta);
+        when(message.getHeaders()).thenReturn(headers);
+        when(delta.getContextId()).thenReturn(CONTEXT_ID);
+        when(joinPoint.proceed()).thenThrow(RetryableException.class);
+
+        // when
+        Executable actual = () -> aspect.manageStructuredLogging(joinPoint);
+
+        //then
+        assertThrows(RetryableException.class, actual);
+        assertTrue(capture.getOut().contains("RetryableException exception thrown"));
+        verifyInfoLogMap(capture);
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldLogInfoWhenRetryableExceptionMaxAttempts(CapturedOutput capture) throws Throwable {
+        // given
+        MessageHeaders headers = new MessageHeaders(
+                Map.of(
+                        // attempts header returns a byte array not an integer
+                        DEFAULT_HEADER_ATTEMPTS, ByteBuffer.allocate(4).putInt(5).array(),
+                        RECEIVED_TOPIC, TOPIC,
+                        RECEIVED_PARTITION, 0,
+                        OFFSET, 0L));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{message});
+        when(message.getPayload()).thenReturn(delta);
+        when(message.getHeaders()).thenReturn(headers);
+        when(delta.getContextId()).thenReturn(CONTEXT_ID);
+        when(joinPoint.proceed()).thenThrow(RetryableException.class);
+
+        // when
+        Executable actual = () -> aspect.manageStructuredLogging(joinPoint);
+
+        //then
+        assertThrows(RetryableException.class, actual);
+        assertTrue(ERROR_EVENT_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(MAX_RETRY_ATTEMPTS_REACHED_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(REQUEST_ID_INITIALISED_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(RETRY_COUNT_FOUR_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(MAIN_TOPIC_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(PARTITION_ZERO_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(OFFSET_ZERO_PATTERN.matcher(capture.getOut()).find());
+    }
+
+    @Test
+    @ExtendWith(OutputCaptureExtension.class)
+    void shouldLogInfoWhenInvalidPayload(CapturedOutput capture) {
+        // given
+        MessageHeaders headers = new MessageHeaders(
+                Map.of(
+                        RECEIVED_TOPIC, TOPIC,
+                        RECEIVED_PARTITION, 0,
+                        OFFSET, 0L));
+        when(joinPoint.getArgs()).thenReturn(new Object[]{invalidMessage});
+        when(invalidMessage.getPayload()).thenReturn("message payload");
+        when(invalidMessage.getHeaders()).thenReturn(headers);
+
+        // when
+        Executable actual = () -> aspect.manageStructuredLogging(joinPoint);
+
+        //then
+        assertThrows(NonRetryableException.class, actual);
+        assertTrue(ERROR_EVENT_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(INVALID_PAYLOAD_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(REQUEST_ID_UNINITIALISED_PATTERN.matcher(capture.getOut()).find());
+        assertFalse(capture.getOut().contains("retry_count"));
+        assertFalse(capture.getOut().contains("topic"));
+        assertFalse(capture.getOut().contains("partition"));
+        assertFalse(capture.getOut().contains("offset"));
+    }
+
+    private static void verifyInfoLogMap(CapturedOutput capture) {
+        assertTrue(INFO_EVENT_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(REQUEST_ID_INITIALISED_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(RETRY_COUNT_ZERO_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(MAIN_TOPIC_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(PARTITION_ZERO_PATTERN.matcher(capture.getOut()).find());
+        assertTrue(OFFSET_ZERO_PATTERN.matcher(capture.getOut()).find());
+    }
+}

--- a/src/test/resources/data/delete-delta.json
+++ b/src/test/resources/data/delete-delta.json
@@ -1,5 +1,10 @@
 {
   "entity_id": "131854271",
   "action": "DELETE",
-  "delta_at": "20230724093435661593"
+  "delta_at": "20230724093435661593",
+  "barcode": "",
+  "parent_entity_id": "3043972675",
+  "parent_form_type": "TM01",
+  "form_type": "ANNOTATION",
+  "company_number": "12345678"
 }


### PR DESCRIPTION
## Describe the changes
This PR bumps up the Private SDK version to bring in FH Delete Delta spec changes (some additional fields). 

Also, I have refactored the logging kafka listener aspect to use the MessageHeaders object instead of getting headers from an array using index numbers. With this, I also copied across the test for this aspect from ACSP Delta Consumer.

### Related Jira tickets
[DSND-3122](https://companieshouse.atlassian.net/browse/DSND-3122)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-3122]: https://companieshouse.atlassian.net/browse/DSND-3122?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ