### PR TITLE
DSND-3241: Add parent entity id to delete request headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ test-unit:
 test-integration:
 	mvn clean verify -Dskip.unit.tests=true -Dskip.integration.tests=false
 
+.PHONY: docker-image
+docker-image: clean
+	mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
+
 .PHONY: package
 package:
 ifndef version

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ immediately to the <br>`filing-history-delta-filing-history-delta-consumer-inval
 
 ## Building the docker image
 ```bash
-mvn package -Dskip.unit.tests=true -Dskip.integration.tests=true jib:dockerBuild
+make docker-image
 ```
 
 ## To make local changes

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.20</structured-logging.version>
     <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
+    <private-api-sdk-java.version>4.0.265</private-api-sdk-java.version>
     <kafka-models.version>3.0.8</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->

--- a/pom.xml
+++ b/pom.xml
@@ -16,14 +16,13 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.3.5</spring.boot.version>
-    <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
-    <test-containers.version>1.20.3</test-containers.version>
-    <maven-surefire.version>3.5.1</maven-surefire.version>
+    <spring.boot.version>3.4.2</spring.boot.version>
+    <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
+    <maven-surefire.version>3.5.2</maven-surefire.version>
     <maven-surefire-plugin.version>${maven-surefire.version}</maven-surefire-plugin.version>
     <maven-failsafe-plugin.version>${maven-surefire.version}</maven-failsafe-plugin.version>
-    <commons-text.version>1.12.0</commons-text.version>
-    <wiremock.version>3.9.2</wiremock.version>
+    <commons-text.version>1.13.0</commons-text.version>
+    <wiremock.version>3.11.0</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>
@@ -53,13 +52,6 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>${test-containers.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 
@@ -69,12 +61,6 @@
       <groupId>org.apache.avro</groupId>
       <artifactId>avro</artifactId>
       <version>1.12.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.xmlunit</groupId>
-      <artifactId>xmlunit-core</artifactId>
-      <version>2.10.0</version>
-      <scope>test</scope>
     </dependency>
     <!--end transitive dependencies-->
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <!--companies house-->
     <structured-logging.version>3.0.20</structured-logging.version>
     <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
-    <private-api-sdk-java.version>4.0.234</private-api-sdk-java.version>
+    <private-api-sdk-java.version>unversioned</private-api-sdk-java.version>
     <kafka-models.version>3.0.8</kafka-models.version>
 
     <!--explicit versions of transitive dependencies with vulnerabilities in previous versions-->

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClient.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClient.java
@@ -1,9 +1,6 @@
 package uk.gov.companieshouse.filinghistory.consumer.apiclient;
 
-import static uk.gov.companieshouse.filinghistory.consumer.Application.NAMESPACE;
-
 import java.util.function.Supplier;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -11,8 +8,6 @@ import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.filinghistory.consumer.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.consumer.service.DeleteApiClientRequest;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class FilingHistoryApiClient {
@@ -57,7 +52,7 @@ public class FilingHistoryApiClient {
         try {
             client.privateDeltaResourceHandler()
                     .deleteFilingHistory(formattedUri, apiClientRequest.deltaAt(),
-                            apiClientRequest.entityId())
+                            apiClientRequest.entityId(), apiClientRequest.parentEntityId())
                     .execute();
         } catch (ApiErrorResponseException ex) {
             responseHandler.handle(ex);

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteApiClientRequest.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteApiClientRequest.java
@@ -1,5 +1,47 @@
 package uk.gov.companieshouse.filinghistory.consumer.service;
 
-public record DeleteApiClientRequest(String transactionId, String companyNumber, String entityId, String deltaAt) {
+public record DeleteApiClientRequest(String transactionId, String companyNumber, String entityId, String deltaAt, String parentEntityId) {
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String transactionId;
+        private String companyNumber;
+        private String entityId;
+        private String deltaAt;
+        private String parentEntityId;
+
+        public Builder transactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public Builder companyNumber(String companyNumber) {
+            this.companyNumber = companyNumber;
+            return this;
+        }
+
+        public Builder entityId(String entityId) {
+            this.entityId = entityId;
+            return this;
+        }
+
+        public Builder deltaAt(String deltaAt) {
+            this.deltaAt = deltaAt;
+            return this;
+        }
+
+        public Builder parentEntityId(String parentEntityId) {
+            this.parentEntityId = parentEntityId;
+            return this;
+        }
+
+        public DeleteApiClientRequest build() {
+            return new DeleteApiClientRequest(transactionId, companyNumber, entityId, deltaAt, parentEntityId);
+        }
+    }
 
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaService.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaService.java
@@ -32,8 +32,15 @@ public class DeleteDeltaService implements DeltaService {
                 deleteDelta.getBarcode());
 
         TransactionKindResult kindResult = kindService.encodeIdByTransactionKind(criteria);
-        DeleteApiClientRequest clientRequest = new DeleteApiClientRequest(kindResult.encodedId(),
-                deleteDelta.getCompanyNumber(), deleteDelta.getEntityId(), deleteDelta.getDeltaAt());
+
+        DeleteApiClientRequest clientRequest = DeleteApiClientRequest.builder()
+                .transactionId(kindResult.encodedId())
+                .companyNumber(deleteDelta.getCompanyNumber())
+                .entityId(deleteDelta.getEntityId())
+                .deltaAt(deleteDelta.getDeltaAt())
+                .parentEntityId(deleteDelta.getParentEntityId())
+                .build();
+
         apiClient.deleteFilingHistory(clientRequest);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/apiclient/FilingHistoryApiClientTest.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.filinghistory.consumer.apiclient;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
@@ -10,7 +9,6 @@ import static org.mockito.Mockito.when;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -35,10 +33,17 @@ class FilingHistoryApiClientTest {
     private static final String COMPANY_NUMBER = "12345678";
     private static final String TRANSACTION_ID = "MzA0Mzk3MjY3NXNhbHQ";
     private static final String ENTITY_ID = "1234567891";
+    private static final String PARENT_ENTITY_ID = "2234567891";
     private static final String REQUEST_ID = "request_id";
     private static final String DELTA_AT = "20240219123045999999";
     private static final DeleteApiClientRequest API_CLIENT_REQUEST =
-            new DeleteApiClientRequest(TRANSACTION_ID, COMPANY_NUMBER,ENTITY_ID, DELTA_AT);
+            DeleteApiClientRequest.builder()
+                    .transactionId(TRANSACTION_ID)
+                    .companyNumber(COMPANY_NUMBER)
+                    .entityId(ENTITY_ID)
+                    .deltaAt(DELTA_AT)
+                    .parentEntityId(PARENT_ENTITY_ID)
+                    .build();
 
     @InjectMocks
     private FilingHistoryApiClient filingHistoryApiClient;
@@ -155,7 +160,7 @@ class FilingHistoryApiClientTest {
         when(internalApiClientFactory.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(apiClient);
         when(internalApiClient.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString()))
+        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString(), anyString()))
                 .thenReturn(privateFilingHistoryDelete);
 
         DataMapHolder.get().requestId(REQUEST_ID);
@@ -167,7 +172,7 @@ class FilingHistoryApiClientTest {
         // then
         verify(apiClient).setRequestId(REQUEST_ID);
         verify(internalApiClient).privateDeltaResourceHandler();
-        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID);
+        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID, PARENT_ENTITY_ID);
         verify(privateFilingHistoryDelete).execute();
         verifyNoInteractions(responseHandler);
     }
@@ -180,7 +185,8 @@ class FilingHistoryApiClientTest {
         when(internalApiClientFactory.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(apiClient);
         when(internalApiClient.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString())).thenReturn(privateFilingHistoryDelete);
+        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                privateFilingHistoryDelete);
         when(privateFilingHistoryDelete.execute()).thenThrow(exceptionClass);
 
         DataMapHolder.get().requestId(REQUEST_ID);
@@ -192,7 +198,7 @@ class FilingHistoryApiClientTest {
         // then
         verify(apiClient).setRequestId(REQUEST_ID);
         verify(internalApiClient).privateDeltaResourceHandler();
-        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID);
+        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID, PARENT_ENTITY_ID);
         verify(privateFilingHistoryDelete).execute();
         verify(responseHandler).handle(any(exceptionClass));
     }
@@ -205,7 +211,8 @@ class FilingHistoryApiClientTest {
         when(internalApiClientFactory.get()).thenReturn(internalApiClient);
         when(internalApiClient.getHttpClient()).thenReturn(apiClient);
         when(internalApiClient.privateDeltaResourceHandler()).thenReturn(privateDeltaResourceHandler);
-        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString())).thenReturn(privateFilingHistoryDelete);
+        when(privateDeltaResourceHandler.deleteFilingHistory(anyString(), anyString(), anyString(), anyString())).thenReturn(
+                privateFilingHistoryDelete);
         when(privateFilingHistoryDelete.execute()).thenThrow(exceptionClass);
 
         DataMapHolder.get().requestId(REQUEST_ID);
@@ -217,7 +224,7 @@ class FilingHistoryApiClientTest {
         // then
         verify(apiClient).setRequestId(REQUEST_ID);
         verify(internalApiClient).privateDeltaResourceHandler();
-        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID);
+        verify(privateDeltaResourceHandler).deleteFilingHistory(expectedUri, DELTA_AT, ENTITY_ID, PARENT_ENTITY_ID);
         verify(privateFilingHistoryDelete).execute();
         verify(responseHandler).handle(any(exceptionClass));
     }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/AbstractKafkaIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/AbstractKafkaIT.java
@@ -3,9 +3,9 @@ package uk.gov.companieshouse.filinghistory.consumer.kafka;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Testcontainers
@@ -13,7 +13,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class AbstractKafkaIT {
 
     @Container
-    protected static final KafkaContainer kafka = new KafkaContainer(DockerImageName.parse(
+    protected static final ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(DockerImageName.parse(
             "confluentinc/cp-kafka:latest"));
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerInvalidPayloadExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerInvalidPayloadExceptionIT.java
@@ -20,10 +20,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.filinghistory.consumer.service.DeltaServiceRouter;
 
 @SpringBootTest
@@ -35,7 +35,7 @@ class ConsumerInvalidPayloadExceptionIT extends AbstractKafkaIT {
     @Autowired
     private KafkaProducer<String, byte[]> testProducer;
 
-    @MockBean
+    @MockitoBean
     private DeltaServiceRouter deltaServiceRouter;
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerNonRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerNonRetryableExceptionIT.java
@@ -25,10 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.filinghistory.consumer.exception.NonRetryableException;
 import uk.gov.companieshouse.filinghistory.consumer.service.DeltaServiceRouter;
@@ -45,7 +45,7 @@ class ConsumerNonRetryableExceptionIT extends AbstractKafkaIT {
     @Autowired
     private TestConsumerAspect testConsumerAspect;
 
-    @MockBean
+    @MockitoBean
     private DeltaServiceRouter deltaServiceRouter;
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.filinghistory.consumer.kafka;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -192,6 +193,8 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
 
-        verify(requestMadeFor(new PutRequestMatcher(expectedRequestUri, expectedRequestBody)));
+        verify(requestMadeFor(new PutRequestMatcher(expectedRequestUri, expectedRequestBody))
+                .withHeader("X-REQUEST-ID", equalTo("context_id"))
+        );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveIT.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.filinghistory.consumer.kafka;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -101,7 +102,9 @@ class ConsumerPositiveIT extends AbstractKafkaIT {
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
 
-        verify(requestMadeFor(new PutRequestMatcher(expectedRequestUri, expectedRequestBody)));
+        verify(requestMadeFor(new PutRequestMatcher(expectedRequestUri, expectedRequestBody))
+                .withHeader("X-REQUEST-ID", equalTo("context_id"))
+        );
     }
 
     @Test
@@ -138,6 +141,11 @@ class ConsumerPositiveIT extends AbstractKafkaIT {
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, ERROR_TOPIC)).isZero();
         assertThat(KafkaUtils.noOfRecordsForTopic(consumerRecords, INVALID_TOPIC)).isZero();
 
-        verify(deleteRequestedFor(urlEqualTo(expectedRequestUri)));
+        verify(deleteRequestedFor(urlEqualTo(expectedRequestUri))
+                .withHeader("X-REQUEST-ID", equalTo("context_id"))
+                .withHeader("X-DELTA-AT", equalTo("20230724093435661593"))
+                .withHeader("X-ENTITY-ID", equalTo("131854271"))
+                .withHeader("X-PARENT-ENTITY-ID", equalTo("3043972675"))
+        );
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerRetryableExceptionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerRetryableExceptionIT.java
@@ -26,10 +26,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.kafka.test.utils.KafkaTestUtils;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.filinghistory.consumer.exception.RetryableException;
 import uk.gov.companieshouse.filinghistory.consumer.service.DeltaServiceRouter;
@@ -46,7 +46,7 @@ class ConsumerRetryableExceptionIT extends AbstractKafkaIT {
     @Autowired
     private TestConsumerAspect testConsumerAspect;
 
-    @MockBean
+    @MockitoBean
     private DeltaServiceRouter deltaServiceRouter;
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/service/DeleteDeltaServiceTest.java
@@ -18,12 +18,23 @@ import uk.gov.companieshouse.filinghistory.consumer.serdes.FilingHistoryDeltaDes
 @ExtendWith(MockitoExtension.class)
 class DeleteDeltaServiceTest {
 
+    private static final String CONTEXT_ID = "context_id";
+    private static final String TRANSACTION_ID = "ABCD1234EFGH";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String ENTITY_ID = "98765432";
+    private static final String DELTA_AT = "20240219123045999999";
+    private static final String PARENT_ENTITY_ID = "88765432";
     private static final String DELTA_DATA = "delta";
     private static final TransactionKindResult KIND_RESULT =
-            new TransactionKindResult("ABCD1234EFGH", TransactionKindEnum.ANNOTATION);
+            new TransactionKindResult(TRANSACTION_ID, TransactionKindEnum.ANNOTATION);
     private static final DeleteApiClientRequest API_CLIENT_REQUEST =
-            new DeleteApiClientRequest("ABCD1234EFGH", "12345678",
-                    "98765432", "20240219123045999999");
+            DeleteApiClientRequest.builder()
+                    .transactionId(TRANSACTION_ID)
+                    .companyNumber(COMPANY_NUMBER)
+                    .entityId(ENTITY_ID)
+                    .deltaAt(DELTA_AT)
+                    .parentEntityId(PARENT_ENTITY_ID)
+                    .build();
 
     @InjectMocks
     private DeleteDeltaService service;
@@ -41,11 +52,12 @@ class DeleteDeltaServiceTest {
         // given
         when(deserialiser.deserialiseFilingHistoryDeleteDelta(any())).thenReturn(delta);
         when(kindService.encodeIdByTransactionKind(any())).thenReturn(KIND_RESULT);
-        when(delta.getDeltaAt()).thenReturn("20240219123045999999");
-        when(delta.getEntityId()).thenReturn("98765432");
-        when(delta.getCompanyNumber()).thenReturn("12345678");
+        when(delta.getDeltaAt()).thenReturn(DELTA_AT);
+        when(delta.getEntityId()).thenReturn(ENTITY_ID);
+        when(delta.getCompanyNumber()).thenReturn(COMPANY_NUMBER);
+        when(delta.getParentEntityId()).thenReturn(PARENT_ENTITY_ID);
 
-        ChsDelta chsDelta = new ChsDelta(DELTA_DATA, 0, "contextId", true);
+        ChsDelta chsDelta = new ChsDelta(DELTA_DATA, 0, CONTEXT_ID, true);
 
         // when
         service.process(chsDelta);


### PR DESCRIPTION
## Describe the changes
This PR adds the parent entity id to the request headers to to FH Data API's delete endpoint.

### Related Jira tickets
[DSND-3241](https://companieshouse.atlassian.net/browse/DSND-3241)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[DSND-3241]: https://companieshouse.atlassian.net/browse/DSND-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ