### PR TITLE
BI-14445: Amend PSC01 rules to allow missing fields

### DIFF
--- a/src/main/resources/transform_rules.yml
+++ b/src/main/resources/transform_rules.yml
@@ -16603,11 +16603,27 @@
     eq:
       data.type: PSC01
     like:
-      data.description: '^(?i:NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL)$'
+      data.description: '^(?i:NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL (?<pscName>.+?))$'
+      original_values.notification_date: '^(?<notificationDate>\d+\D\d+\D\d+)$'
   then:
     set:
       data.category: persons-with-significant-control
-      data.description: notification-of-a-person-with-significant-control-without-name-date
+      data.description: notification-of-a-person-with-significant-control
+      data.description_values.psc_name: '[% pscName | title_case %]'
+      data.subcategory: notifications
+      original_description: '[% data.description | sentence_case %]'
+      data.action_date: '[% notificationDate | bson_date %]'
+      data.description_values.notification_date: '[% notificationDate | bson_date %]'
+- when:
+    eq:
+      data.type: PSC01
+    like:
+      data.description: '^(?i:NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL (?<pscName>.+?))$'
+  then:
+    set:
+      data.category: persons-with-significant-control
+      data.description: notification-of-a-person-with-significant-control-with-name
+      data.description_values.psc_name: '[% pscName | title_case %]'
       data.subcategory: notifications
       original_description: '[% data.description | sentence_case %]'
 - when:
@@ -16616,12 +16632,9 @@
   then:
     set:
       data.category: persons-with-significant-control
-      data.description: notification-of-a-person-with-significant-control
-      data.description_values.psc_name: '[% original_values.psc_name | title_case %]'
+      data.description: notification-of-a-person-with-significant-control-without-name-date
       data.subcategory: notifications
       original_description: '[% data.description | sentence_case %]'
-      data.action_date: '[% original_values.notification_date | bson_date %]'
-      data.description_values.notification_date: '[% original_values.notification_date | bson_date %]'
 - when:
     eq:
       data.type: PSC02

--- a/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/consumer/kafka/ConsumerPositiveComprehensiveIT.java
@@ -143,7 +143,9 @@ class ConsumerPositiveComprehensiveIT extends AbstractKafkaIT {
             "persons-with-significant-control/LLPSC07", "persons-with-significant-control/LLPSC07_no_description_values",
             "persons-with-significant-control/PSC07", "persons-with-significant-control/PSC07_no_description_values",
             "persons-with-significant-control/SLPPSC07", "persons-with-significant-control/SLPPSC07_no_description_values",
-            "persons-with-significant-control/SQPPSC07", "persons-with-significant-control/SQPPSC07_no_description_values"
+            "persons-with-significant-control/SQPPSC07", "persons-with-significant-control/SQPPSC07_no_description_values",
+            "persons-with-significant-control/PSC01_name_and_date", "persons-with-significant-control/PSC01_name_no_date",
+            "persons-with-significant-control/PSC01_date_no_name", "persons-with-significant-control/PSC01_no_name_no_date"
     })
     void shouldConsumeFilingHistoryDeltaTopicAndProcessDeltaFromCSV(final String prefix) throws Exception {
         final String delta = IOUtils.resourceToString("/data/%s_delta.json".formatted(prefix), StandardCharsets.UTF_8);

--- a/src/test/resources/data/persons-with-significant-control/PSC01_date_no_name_delta.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_date_no_name_delta.json
@@ -1,0 +1,22 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20240910131020",
+      "form_type": "PSC01",
+      "description": "NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL",
+      "barcode": "XDBC6C3V",
+      "document_id": "000XDBC6C3V9308",
+      "company_number": "14575942",
+      "entity_id": "3435154857",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "description_values": {
+        "notification_date": "14/08/2017",
+        "psc_name": ""
+      },
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20250507101150570002"
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_date_no_name_request_body.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_date_no_name_request_body.json
@@ -1,0 +1,27 @@
+{
+  "external_data": {
+    "transaction_id": "MzQzNTE1NDg1N3NhbHQ",
+    "barcode": "XDBC6C3V",
+    "type": "PSC01",
+    "date": "2024-09-10T13:10:20Z",
+    "category": "persons-with-significant-control",
+    "subcategory": "notifications",
+    "description": "notification-of-a-person-with-significant-control-without-name-date",
+    "links": {
+      "self": "/company/14575942/filing-history/MzQzNTE1NDg1N3NhbHQ"
+    }
+  },
+  "internal_data": {
+    "entity_id": "3435154857",
+    "company_number": "14575942",
+    "document_id": "000XDBC6C3V9308",
+    "original_description": "Notification of a person with significant control",
+    "original_values": {
+      "notification_date": "14/08/2017"
+    },
+    "delta_at": "20250507101150570002",
+    "parent_entity_id": "",
+    "transaction_kind": "top-level",
+    "updated_by": "context_id"
+  }
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_name_and_date_delta.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_name_and_date_delta.json
@@ -1,0 +1,22 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20240910131020",
+      "form_type": "PSC01",
+      "description": "NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL JOHN TESTER",
+      "barcode": "XDBC6C3V",
+      "document_id": "000XDBC6C3V9308",
+      "company_number": "14575942",
+      "entity_id": "3435154857",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "description_values": {
+        "notification_date": "14/08/2017",
+        "psc_name": "JOHN TESTER"
+      },
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20250507101150570002"
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_name_and_date_request_body.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_name_and_date_request_body.json
@@ -1,0 +1,33 @@
+{
+  "external_data": {
+    "transaction_id": "MzQzNTE1NDg1N3NhbHQ",
+    "barcode": "XDBC6C3V",
+    "type": "PSC01",
+    "date": "2024-09-10T13:10:20Z",
+    "category": "persons-with-significant-control",
+    "subcategory": "notifications",
+    "description": "notification-of-a-person-with-significant-control",
+    "description_values": {
+      "notification_date": "2017-08-14T00:00:00Z",
+      "psc_name": "John Tester"
+    },
+    "action_date": "2017-08-14T00:00:00Z",
+    "links": {
+      "self": "/company/14575942/filing-history/MzQzNTE1NDg1N3NhbHQ"
+    }
+  },
+  "internal_data": {
+    "entity_id": "3435154857",
+    "company_number": "14575942",
+    "document_id": "000XDBC6C3V9308",
+    "original_description": "Notification of a person with significant control john tester",
+    "original_values": {
+      "notification_date": "14/08/2017",
+      "psc_name": "JOHN TESTER"
+    },
+    "delta_at": "20250507101150570002",
+    "parent_entity_id": "",
+    "transaction_kind": "top-level",
+    "updated_by": "context_id"
+  }
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_name_no_date_delta.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_name_no_date_delta.json
@@ -1,0 +1,22 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20240910131020",
+      "form_type": "PSC01",
+      "description": "NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL JOHN TESTER",
+      "barcode": "XDBC6C3V",
+      "document_id": "000XDBC6C3V9308",
+      "company_number": "14575942",
+      "entity_id": "3435154857",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "description_values": {
+        "notification_date": "",
+        "psc_name": "JOHN TESTER"
+      },
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20250507101150570002"
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_name_no_date_request_body.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_name_no_date_request_body.json
@@ -1,0 +1,30 @@
+{
+  "external_data": {
+    "transaction_id": "MzQzNTE1NDg1N3NhbHQ",
+    "barcode": "XDBC6C3V",
+    "type": "PSC01",
+    "date": "2024-09-10T13:10:20Z",
+    "category": "persons-with-significant-control",
+    "subcategory": "notifications",
+    "description": "notification-of-a-person-with-significant-control-with-name",
+    "description_values": {
+      "psc_name": "John Tester"
+    },
+    "links": {
+      "self": "/company/14575942/filing-history/MzQzNTE1NDg1N3NhbHQ"
+    }
+  },
+  "internal_data": {
+    "entity_id": "3435154857",
+    "company_number": "14575942",
+    "document_id": "000XDBC6C3V9308",
+    "original_description": "Notification of a person with significant control john tester",
+    "original_values": {
+      "psc_name": "JOHN TESTER"
+    },
+    "delta_at": "20250507101150570002",
+    "parent_entity_id": "",
+    "transaction_kind": "top-level",
+    "updated_by": "context_id"
+  }
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_no_name_no_date_delta.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_no_name_no_date_delta.json
@@ -1,0 +1,18 @@
+{
+  "filing_history": [
+    {
+      "category": "9",
+      "receive_date": "20240910131020",
+      "form_type": "PSC01",
+      "description": "NOTIFICATION OF A PERSON WITH SIGNIFICANT CONTROL",
+      "barcode": "XDBC6C3V",
+      "document_id": "000XDBC6C3V9308",
+      "company_number": "14575942",
+      "entity_id": "3435154857",
+      "parent_entity_id": "",
+      "parent_form_type": "",
+      "pre_scanned_batch": "0"
+    }
+  ],
+  "delta_at": "20250507101150570002"
+}

--- a/src/test/resources/data/persons-with-significant-control/PSC01_no_name_no_date_request_body.json
+++ b/src/test/resources/data/persons-with-significant-control/PSC01_no_name_no_date_request_body.json
@@ -1,0 +1,24 @@
+{
+  "external_data": {
+    "transaction_id": "MzQzNTE1NDg1N3NhbHQ",
+    "barcode": "XDBC6C3V",
+    "type": "PSC01",
+    "date": "2024-09-10T13:10:20Z",
+    "category": "persons-with-significant-control",
+    "subcategory": "notifications",
+    "description": "notification-of-a-person-with-significant-control-without-name-date",
+    "links": {
+      "self": "/company/14575942/filing-history/MzQzNTE1NDg1N3NhbHQ"
+    }
+  },
+  "internal_data": {
+    "entity_id": "3435154857",
+    "company_number": "14575942",
+    "document_id": "000XDBC6C3V9308",
+    "original_description": "Notification of a person with significant control",
+    "delta_at": "20250507101150570002",
+    "parent_entity_id": "",
+    "transaction_kind": "top-level",
+    "updated_by": "context_id"
+  }
+}


### PR DESCRIPTION
## Describe the changes
* Changes transorm_rules.yml to allow PSC01 transactions to have a mix of field variations: 
  * both name and date
  * with name but without date
  * with date but without name
  * neither name nor date

### Related Jira tickets
[BI-14445](https://companieshouse.atlassian.net/browse/BI-14445)

## Developer check list
### General
- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing
- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation
_Where possible, add links to the respective Jira tickets when an item is checked_
- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to `chs-configs`?

## Notes to the tester
_Add any testing hints or instructions here._


[BI-14445]: https://companieshouse.atlassian.net/browse/BI-14445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ